### PR TITLE
Initial implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: python
+python: 3.7
+
+dist: xenial
+
+before_install:
+  - make docker-rabbitmq-run
+  - make docker-redis-run
+
+install:
+  - pip install tox
+
+matrix:
+  include:
+    - stage: test
+      python: 3.4
+      env: TOX_ENV=py34
+
+    - stage: test
+      python: 3.5
+      env: TOX_ENV=py35
+
+    - stage: test
+      python: 3.6
+      env: TOX_ENV=py36
+
+    - stage: test
+      python: 3.7
+      env: TOX_ENV=py37
+
+script:
+  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python: 3.7
 dist: xenial
 
 before_install:
-  - make docker-rabbitmq-run
-  - make docker-redis-run
+  - make rabbitmq-container
+  - make redis-container
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,13 @@ matrix:
   include:
     - stage: test
       python: 3.4
-      env: TOX_ENV=py34
-
-    - stage: test
-      python: 3.5
-      env: TOX_ENV=py35
-
-    - stage: test
-      python: 3.6
-      env: TOX_ENV=py36
-
-    - stage: test
-      python: 3.7
-      env: TOX_ENV=py37
+      env: TOX_ENV="py34-nameko{2.11,2.12,latest}"
+    - python: 3.5
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}"
+    - python: 3.6
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}"
+    - python: 3.7
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}"
 
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: 3.7
 
 dist: xenial
 
@@ -12,7 +13,7 @@ install:
 matrix:
   include:
     - stage: test
-    - python: 3.5
+      python: 3.5
       env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis2.10"
     - python: 3.5
       env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,6 @@ install:
 matrix:
   include:
     - stage: test
-      python: 3.4
-      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis2.10"
-    - python: 3.4
-      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis3.0"
-    - python: 3.4
-      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis3.1"
-    - python: 3.4
-      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis3.2"
-    - python: 3.4
-      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redislatest"
-
     - python: 3.5
       env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis2.10"
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-python: 3.7
 
 dist: xenial
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,48 @@ matrix:
   include:
     - stage: test
       python: 3.4
-      env: TOX_ENV="py34-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis2.10"
+    - python: 3.4
+      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis3.0"
+    - python: 3.4
+      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis3.1"
+    - python: 3.4
+      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redis3.2"
+    - python: 3.4
+      env: TOX_ENV="py34-nameko{2.11,2.12,latest}-redislatest"
+
     - python: 3.5
-      env: TOX_ENV="py35-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis2.10"
+    - python: 3.5
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.0"
+    - python: 3.5
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.1"
+    - python: 3.5
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.2"
+    - python: 3.5
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redislatest"
+
     - python: 3.6
-      env: TOX_ENV="py36-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis2.10"
+    - python: 3.6
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.0"
+    - python: 3.6
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.1"
+    - python: 3.6
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.2"
+    - python: 3.6
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redislatest"
+
     - python: 3.7
-      env: TOX_ENV="py37-nameko{2.11,2.12,latest}"
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis2.10"
+    - python: 3.7
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.0"
+    - python: 3.7
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.1"
+    - python: 3.7
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.2"
+    - python: 3.7
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redislatest"
 
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Released 2019-xx-xx
   - Add ability to subscribe to events
   - Add ability to subscribe to keys
   - Add ability to subscribe to databases
-* Support for Python ``3.4``, ``3.5``, ``3.6``, ``3.7`` (#1)
+* Support for Python ``3.5``, ``3.6``, ``3.7`` (#1)
 * Supoort for Nameko ``2.11``, ``2.12`` (#1)
 * Add support for (Python) Redis ``2.10``, ``3.0``, ``3.1``, ``3.2``
   (#1)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,24 @@
+Version History
+===============
+
+Here you can see the full list of changes between
+nameko-rediskn versions, where semantic versioning is used:
+**major.minor.patch**.
+
+Backwards-compatible changes increment the minor version number only.
+
+
+0.1.0
+-----
+
+Released 2019-xx-xx
+
+* Initial release of the library (#1)
+  - Add ability to subscribe to events
+  - Add ability to subscribe to keys
+  - Add ability to subscribe to databases
+* Support for Python ``3.4``, ``3.5``, ``3.6``, ``3.7`` (#1)
+* Supoort for Nameko ``2.11``, ``2.12`` (#1)
+* Add support for (Python) Redis ``2.10``, ``3.0``, ``3.1``, ``3.2``
+  (#1)
+* Add support for Redis ``4.0`` (#1)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,11 @@ Backwards-compatible changes increment the minor version number only.
 Released 2019-xx-xx
 
 * Initial release of the library (#1)
-  - Add ability to subscribe to events
-  - Add ability to subscribe to keys
-  - Add ability to subscribe to databases
-* Support for Python ``3.5``, ``3.6``, ``3.7`` (#1)
-* Supoort for Nameko ``2.11``, ``2.12`` (#1)
+  - Add the ability to subscribe to events
+  - Add the ability to subscribe to keys
+  - Add the ability to subscribe to databases
+* Add support for Python ``3.5``, ``3.6``, ``3.7`` (#1)
+* Add support for Nameko ``2.11``, ``2.12``, ``3.0`` (#1)
 * Add support for (Python) Redis ``2.10``, ``3.0``, ``3.1``, ``3.2``
   (#1)
 * Add support for Redis ``4.0`` (#1)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,4 @@
+Contributions have been made by:
+
+Alex Peitsinis (@alexpeits)
+Julio Trigo (@juliotrigo)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include CHANGELOG.rst
+include LICENSE
+include README.rst
+
+global-exclude __pycache__
+global-exclude *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include CHANGELOG.rst
+include CONTRIBUTORS.txt
 include LICENSE
 include README.rst
 

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ coverage: rst-lint flake8
 
 # Docker test containers
 
-docker-rabbitmq-run:
+rabbitmq-container:
 	docker run -d --rm --name rabbitmq-nameko-rediskn \
 		-p 15672:15672 -p 5672:5672 \
 		rabbitmq:$(RABBITMQ_VERSION)
 
-docker-redis-run:
+redis-container:
 	docker run -d --rm --name redis-nameko-rediskn \
 		-p 6379:6379 \
 		redis:$(REDIS_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+.PHONY: test
+
+
+PACKAGE_NAME=nameko_rediskn
+
+RABBIT_CTL_URI?=http://guest:guest@localhost:15672
+AMQP_URI?=amqp://guest:guest@localhost:5672
+
+RABBITMQ_VERSION?=3.6-management
+REDIS_VERSION?=4.0
+
+
+rst-lint:
+	rst-lint README.rst
+	rst-lint CHANGELOG.rst
+
+flake8:
+	flake8 $(PACKAGE_NAME) test
+
+test:
+	pytest test $(ARGS) \
+		--rabbit-ctl-uri $(RABBIT_CTL_URI) \
+		--amqp-uri $(AMQP_URI)
+
+coverage: rst-lint flake8
+	coverage run \
+		--concurrency=eventlet \
+		--source $(PACKAGE_NAME) \
+		-m pytest test $(ARGS) \
+		--rabbit-ctl-uri $(RABBIT_CTL_URI) \
+		--amqp-uri $(AMQP_URI)
+	coverage report --show-missing --fail-under 100
+
+# Docker test containers
+
+docker-rabbitmq-run:
+	docker run -d --rm --name rabbitmq-nameko-rediskn \
+		-p 15672:15672 -p 5672:5672 \
+		rabbitmq:$(RABBITMQ_VERSION)
+
+docker-redis-run:
+	docker run -d --rm --name redis-nameko-rediskn \
+		-p 6379:6379 \
+		redis:$(REDIS_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ coverage: rst-lint flake8
 	coverage run \
 		--concurrency=eventlet \
 		--source $(PACKAGE_NAME) \
+		--branch \
 		-m pytest test $(ARGS) \
 		--rabbit-ctl-uri $(RABBIT_CTL_URI) \
 		--amqp-uri $(AMQP_URI)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ rst-lint:
 	rst-lint CHANGELOG.rst
 
 flake8:
-	flake8 $(PACKAGE_NAME) test
+	flake8 $(PACKAGE_NAME) test setup.py
 
 test:
 	pytest test $(ARGS) \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# nameko-rediskn

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Nameko Redis Keyspace Notifications
 .. image:: https://img.shields.io/pypi/format/nameko-rediskn.svg
     :target: https://pypi.org/project/nameko-rediskn/
 
-.. image:: https://travis-ci.org/sohonetlabs/nameko-rediskn.png?branch=master
+.. image:: https://travis-ci.org/sohonetlabs/nameko-rediskn.svg?branch=master
     :target: https://travis-ci.org/sohonetlabs/nameko-rediskn
 
 
@@ -27,8 +27,8 @@ databases.
 
 Some event examples:
 
-    - ``expire`` events fire for ``EXPIRE`` commands
-    - ``expired`` events fire when a key gets deleted due to expiration
+- ``expire`` events fire for ``EXPIRE`` commands
+- ``expired`` events fire when a key gets deleted due to expiration
 
 Usage example:
 
@@ -51,6 +51,21 @@ Usage example:
 
             # ...
 
+Where ``subscribe`` accepts:
+
+- ``MY_REDIS``, which is the attribute name referring to he Redis URI
+  (see the Configuration_ section below).
+- ``events``, ``keys`` and ``dbs`` as a single value (string) or a
+  list of values to subscribe to. They are all optional but at least one
+  of those arguments must be provided.
+
+**NOTE**: this dependency is not "cluster-aware" and fires on all service
+instances. There are different ways to solve that: using ddebounce_ is
+one of them.
+
+
+Configuration
+-------------
 
 Nameko_ configuration file:
 
@@ -159,3 +174,4 @@ The MIT License. See LICENSE_ for details.
 .. _Nameko Redis: https://github.com/etataurov/nameko-redis
 .. _CHANGELOG: https://github.com/sohonetlabs/nameko-rediskn/blob/master/CHANGELOG.rst
 .. _LICENSE: https://github.com/sohonetlabs/nameko-rediskn/blob/master/LICENSE
+.. _ddebounce: https://github.com/iky/ddebounce

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,15 @@ However, this extension should work from, at least, Nameko_ ``2.6``
 onwards.
 
 
+Redis support
+-------------
+
+The following `Redis Python`_ versions are actively supported: ``2.10``,
+``3.0``, ``3.1``, ``3.2``.
+
+Redis_ ``4.0`` is actively supported.
+
+
 Changelog
 ---------
 
@@ -142,6 +151,8 @@ The MIT License. See LICENSE_ for details.
 
 
 .. _Nameko: http://nameko.readthedocs.org
+.. _Redis Python: https://github.com/andymccurdy/redis-py
+.. _Redis: https://redis.io
 .. _Redis Keyspace Notifications: https://redis.io/topics/notifications
 .. _Nameko Redis: https://github.com/etataurov/nameko-redis
 .. _CHANGELOG: https://github.com/sohonetlabs/nameko-rediskn/blob/master/CHANGELOG.rst

--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ variable:
 Nameko support
 --------------
 
-The following Nameko_ versions are supported: ``2.11``.
+The following Nameko_ versions are supported: ``2.11``, ``2.12``.
 
 
 Changelog

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Usage example:
 
         name = 'my-service'
 
-        @rediskn.subscribe(keys='foo/bar-*')
+        @rediskn.subscribe(uri_config_key='MY_REDIS', keys='foo/bar-*')
         def subscriber(self, message):
             event_type = message['data']
             if event_type != 'expired':
@@ -58,18 +58,20 @@ Nameko_ configuration file:
 
     # config.yaml
 
-    REDIS_NOTIFICATION_EVENTS: "KEA"
-    REDIS_URIS:
-        session: "redis://localhost:6380/0"
+    REDIS:
+        NOTIFICATION_EVENTS: "KEA"
 
-``REDIS_NOTIFICATION_EVENTS`` is optional and can be omited or just
+    REDIS_URIS:
+        MY_REDIS: "redis://localhost:6380/0"
+
+``REDIS[NOTIFICATION_EVENTS]`` is optional and can be omited or just
 contain ``None``. Otherwise, it must have a valid value for the
 ``'notify-keyspace-events'`` Redis client configuration attribute. This
 should be ideally set on the server side, as setting it in one of the
 Redis clients will affect the rest of them.
 
 ``REDIS_URIS`` follows the config format used by the `Nameko Redis`_
-dependency provider, where ``session`` is just the attribute name
+dependency provider, where ``MY_REDIS`` is just the attribute name
 refering to the Redis URI of the instance being used.
 
 

--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,11 @@ variable:
 Nameko support
 --------------
 
-The following Nameko_ versions are supported: ``2.11``, ``2.12``.
+The following Nameko_ versions are actively supported: ``2.11``,
+``2.12``.
+
+However, this extension should work from, at least, Nameko_ ``2.6``
+onwards.
 
 
 Changelog

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Usage example:
 
  .. code-block:: python
 
-    from nameko_rediskn import rediskn
+    from nameko_rediskn import rediskn, REDIS_PMESSAGE_TYPE
 
 
     class MyService:
@@ -43,6 +43,9 @@ Usage example:
 
         @rediskn.subscribe(uri_config_key='MY_REDIS', keys='foo/bar-*')
         def subscriber(self, message):
+            if message['type'] != REDIS_PMESSAGE_TYPE:
+                return
+
             event_type = message['data']
             if event_type != 'expired':
                 return
@@ -58,6 +61,9 @@ Where ``subscribe`` accepts:
 - ``events``, ``keys`` and ``dbs`` as a single value (string) or a
   list of values to subscribe to. They are all optional but at least one
   of those arguments must be provided.
+
+For more information, you can check the documentation of the
+``RedisKNEntrypoint`` entrypoint.
 
 **NOTE**: this dependency is not "cluster-aware" and fires on all service
 instances. There are different ways to solve that: using ddebounce_ is

--- a/README.rst
+++ b/README.rst
@@ -80,12 +80,12 @@ Nameko_ configuration file:
     # config.yaml
 
     REDIS:
-        NOTIFICATION_EVENTS: "KEA"
+        notification_events: "KEA"
 
     REDIS_URIS:
         MY_REDIS: "redis://localhost:6380/0"
 
-``REDIS[NOTIFICATION_EVENTS]`` is optional and can be omited or just
+``REDIS[notification_events]`` is optional and can be omited or just
 contain ``None``. Otherwise, it must have a valid value for the
 ``'notify-keyspace-events'`` Redis client configuration attribute. This
 should be ideally set on the server side, as setting it in one of the

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@ databases.
 
 Some event examples:
 
-- ``expire`` events fire for ``EXPIRE`` commands
-- ``expired`` events fire when a key gets deleted due to expiration
+- ``expire`` events fired for ``EXPIRE`` commands
+- ``expired`` events fired when a key gets deleted due to expiration
 
 Usage example:
 

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,13 @@ Nameko support
 The following Nameko_ versions are supported: ``2.11``.
 
 
+Changelog
+---------
+
+Consult the CHANGELOG_ document for fixes and enhancements of each
+version.
+
+
 License
 -------
 
@@ -133,4 +140,5 @@ The MIT License. See LICENSE_ for details.
 .. _Nameko: http://nameko.readthedocs.org
 .. _Redis Keyspace Notifications: https://redis.io/topics/notifications
 .. _Nameko Redis: https://github.com/etataurov/nameko-redis
+.. _CHANGELOG: https://github.com/sohonetlabs/nameko-rediskn/blob/master/CHANGELOG.rst
 .. _LICENSE: https://github.com/sohonetlabs/nameko-rediskn/blob/master/LICENSE

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,136 @@
+Nameko Redis Keyspace Notifications
+===================================
+
+.. pull-quote::
+
+    Nameko_ `Redis Keyspace Notifications`_ extension.
+
+
+.. image:: https://img.shields.io/pypi/v/nameko-rediskn.svg
+    :target: https://pypi.org/project/nameko-rediskn/
+
+.. image:: https://img.shields.io/pypi/pyversions/nameko-rediskn.svg
+    :target: https://pypi.org/project/nameko-rediskn/
+
+.. image:: https://img.shields.io/pypi/format/nameko-rediskn.svg
+    :target: https://pypi.org/project/nameko-rediskn/
+
+.. image:: https://travis-ci.org/sohonetlabs/nameko-rediskn.png?branch=master
+    :target: https://travis-ci.org/sohonetlabs/nameko-rediskn
+
+
+Usage
+-----
+
+This Nameko_ extension adds the ability to subscribe to events, keys and
+databases.
+
+Some event examples:
+
+    - ``expire`` events fire for ``EXPIRE`` commands
+    - ``expired`` events fire when a key gets deleted due to expiration
+
+Usage example:
+
+ .. code-block:: python
+
+    from nameko_rediskn import rediskn
+
+
+    class MyService:
+
+        name = 'my-service'
+
+        @rediskn.subscribe(keys='foo/bar-*')
+        def subscriber(self, message):
+            event_type = message['data']
+            if event_type != 'expired':
+                return
+
+            key = message['channel'].split(':')[1]
+
+            # ...
+
+
+Nameko_ configuration file:
+
+ .. code-block:: yaml
+
+    # config.yaml
+
+    REDIS_NOTIFICATION_EVENTS: "KEA"
+    REDIS_URIS:
+        session: "redis://localhost:6380/0"
+
+``REDIS_NOTIFICATION_EVENTS`` is optional and can be omited or just
+contain ``None``. Otherwise, it must have a valid value for the
+``'notify-keyspace-events'`` Redis client configuration attribute. This
+should be ideally set on the server side, as setting it in one of the
+Redis clients will affect the rest of them.
+
+``REDIS_URIS`` follows the config format used by the `Nameko Redis`_
+dependency provider, where ``session`` is just the attribute name
+refering to the Redis URI of the instance being used.
+
+
+Tests
+-----
+
+It is assumed that **RabbitMQ** is up and running on the default URI
+``guest:guest@localhost`` and uses the default ports.
+
+**Redis** should be also running on the default port.
+
+There are Makefile targets to run both RabbitMQ and Redis docker
+containers locally using the default ports and configuration:
+
+ .. code-block:: shell
+
+    $ make docker-rabbitmq-run
+    $ make docker-redis-run
+
+To run the tests locally:
+
+.. code-block:: shell
+
+    $ # Create/activate a virtual environment
+    $ pip install tox
+    $ tox
+
+There are other Makefile targets to run the tests, but the extra
+dependencies will have to be installed:
+
+.. code-block:: shell
+
+    $ pip install -U --editable ".[dev]"
+    $ make test
+    $ make coverage
+
+A different RabbitMQ URI can be provided overriding the following
+environment variables: ``RABBIT_CTL_URI`` and ``AMQP_URI``.
+
+Additional ``pytest`` parameters can be also provided using the ``ARGS``
+variable:
+
+.. code-block:: shell
+
+    $ make test RABBIT_CTL_URI=http://guest:guest@localhost:15673 AMQP_URI=amqp://guest:guest@localhost:5673 ARGS='-x -vv --disable-warnings'
+    $ make coverage RABBIT_CTL_URI=http://guest:guest@localhost:15673 AMQP_URI=amqp://guest:guest@localhost:5673 ARGS='-x -vv --disable-warnings'
+
+
+Nameko support
+--------------
+
+The following Nameko_ versions are supported: ``2.11``.
+
+
+License
+-------
+
+The MIT License. See LICENSE_ for details.
+
+
+.. _Nameko: http://nameko.readthedocs.org
+.. _Redis Keyspace Notifications: https://redis.io/topics/notifications
+.. _Nameko Redis: https://github.com/etataurov/nameko-redis
+.. _LICENSE: https://github.com/sohonetlabs/nameko-rediskn/blob/master/LICENSE

--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,8 @@ containers locally using the default ports and configuration:
 
  .. code-block:: shell
 
-    $ make docker-rabbitmq-run
-    $ make docker-redis-run
+    $ make rabbitmq-container
+    $ make redis-container
 
 To run the tests locally:
 

--- a/nameko_rediskn/__init__.py
+++ b/nameko_rediskn/__init__.py
@@ -1,0 +1,1 @@
+from .rediskn import REDIS_PMESSAGE_TYPE  # noqa: F401

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -131,20 +131,9 @@ class RedisKNEntrypoint(Entrypoint):
         """
         self.uri_config_key = uri_config_key
 
-        if events is None:
-            self.events = []
-        else:
-            self.events = _to_list(events)
-
-        if keys is None:
-            self.keys = []
-        else:
-            self.keys = _to_list(keys)
-
-        if dbs is None:
-            self.dbs = None
-        else:
-            self.dbs = _to_list(dbs)
+        self.events = [] if events is None else _to_list(events)
+        self.keys = [] if keys is None else _to_list(keys)
+        self.dbs = None if dbs is None else _to_list(dbs)
 
         self.client = None
         self._thread = None

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -6,7 +6,7 @@ from redis import StrictRedis
 from nameko.extensions import Entrypoint
 
 
-REDIS_OPTIONS = {'charset': 'utf-8', 'decode_responses': True}
+REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
 
 NOTIFICATIONS_SETTING_KEY = 'notify-keyspace-events'
 """

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -45,6 +45,9 @@ Keyspace event notifications are received on keys. The key is part of the
 subscription channel, and the event on the key is part of the message data.
 """
 
+REDIS_PMESSAGE_TYPE = 'pmessage'
+"""Pattern-matching subscription message type."""
+
 
 log = logging.getLogger()
 

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -151,7 +151,7 @@ class RedisKNEntrypoint(Entrypoint):
             self.uri_config_key
         ]
         redis_config = self.container.config.get('REDIS', {})
-        self._notification_events = redis_config.get('NOTIFICATION_EVENTS')
+        self._notification_events = redis_config.get('notification_events')
         super().setup()
 
     def start(self):

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -53,12 +53,8 @@ class RedisKNEntrypoint(Entrypoint):
 
     """Redis keyspace notifications entrypoint.
 
+    Key-space notifications and key-event notification as documented here:
     https://redis.io/topics/notifications
-
-    Event examples:
-
-        - `expire` events fire when we call the `EXPIRE` commands
-        - `expired` events fire when a key gets deleted due to expiration
 
     Usage example:
 
@@ -71,6 +67,12 @@ class RedisKNEntrypoint(Entrypoint):
 
             @rediskn.subscribe(uri_config_key='MY_REDIS', keys='foo/bar-*')
             def subscriber(self, message):
+                '''Notifications subscriber entrypoint.
+
+                Args:
+                    message (dict): notification message formed of `type`,
+                    `pattern`, `channel` and `data`.
+                '''
                 event_type = message['data']
                 if event_type != 'expired':
                     return
@@ -152,6 +154,7 @@ class RedisKNEntrypoint(Entrypoint):
         `type`: "pmessage" for simple events, "psubscribe" for subscription
                 events (subscription events are received when the entrypoint
                 initializes)
+
         `pattern`: The subscription pattern
 
         `channel`: The subscription channel
@@ -162,7 +165,7 @@ class RedisKNEntrypoint(Entrypoint):
 
         `db` is the redis database the event comes from. If the subscription
         type is `keyevent`, then the event suffix is the event type (set, hset,
-        expire etc.). If the subscription type is `keyspace`, then the event
+        expire, etc.). If the subscription type is `keyspace`, then the event
         suffix is the key for which the event happened.
         """
         self._create_client()

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -11,28 +11,17 @@ REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
 
 NOTIFICATIONS_SETTING_KEY = 'notify-keyspace-events'
 """
-Configuration parameter used to enable notifications.
+Configuration parameter used to enable keyspace events notifications.
 
-By default, keyspace events notifications are disabled. Setting this parameter
-to the empty string also disables notifications.
+By default, those notifications are disabled. Setting this parameter to the
+empty string also disables them.
 
-To enable them, a non-empty string is used, composed of multiple characters
-from this table:
+To enable them, a non-empty string must be used. The set of allowed characters
+can be found in the Redis keyspace notifications documentation.
 
-K     Keyspace events, published with __keyspace@<db>__ prefix.
-E     Keyevent events, published with __keyevent@<db>__ prefix.
-g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
-$     String commands
-l     List commands
-s     Set commands
-h     Hash commands
-z     Sorted set commands
-x     Expired events (events generated every time a key expires)
-e     Evicted events (events generated when a key is evicted for maxmemory)
-A     Alias for g$lshzxe, so that the "AKE" string means all the events.
-
-NOTE: it is recomended to set it on the server (`redis.conf`), as setting it in
-one of the clients (via the CONFIG SET) also affects the rest of them.
+NOTE: it is recomended to set this parameter on the server side (`redis.conf`),
+as setting it in one of the clients (via the CONFIG SET) also affects the rest
+of them.
 """
 
 KEYEVENT_TEMPLATE = '__keyevent@{db}__:{event}'

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -1,0 +1,230 @@
+import logging
+from itertools import chain
+
+from redis import StrictRedis
+
+from nameko.extensions import Entrypoint
+
+
+REDIS_OPTIONS = {'charset': 'utf-8', 'decode_responses': True}
+
+NOTIFICATIONS_SETTING_KEY = 'notify-keyspace-events'
+"""
+The settings key should be a string consisting of options. Available options
+are:
+
+K     Keyspace events, published with __keyspace@<db>__ prefix.
+E     Keyevent events, published with __keyevent@<db>__ prefix.
+g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
+$     String commands
+l     List commands
+s     Set commands
+h     Hash commands
+z     Sorted set commands
+x     Expired events (events generated every time a key expires)
+e     Evicted events (events generated when a key is evicted for maxmemory)
+A     Alias for g$lshzxe, so that the "AKE" string means all the events.
+
+NOTE: this is set on the server, so it's best to set it once when starting the
+server instance, as setting it in one client affects all other clients.
+However, if this entrypoint finds this setting in the container config it
+applies it.
+"""
+
+KEYEVENT_TEMPLATE = '__keyevent@{db}__:{event}'
+"""
+Keyevent event notifications are received on events. The event is part of the
+subscription channel, and the key the event refers to is part of the message
+data.
+"""
+
+KEYSPACE_TEMPLATE = '__keyspace@{db}__:{key}'
+"""
+Keyspace event notifications are received on keys. The key is part of the
+subscription channel, and the event on the key is part of the message data.
+"""
+
+
+log = logging.getLogger()
+
+
+class RedisKNEntrypoint(Entrypoint):
+
+    """Redis keyspace notifications entrypoint.
+
+    https://redis.io/topics/notifications
+
+    Event examples:
+
+        - `expire` events fire when we call the `EXPIRE` commands
+        - `expired` events fire when a key gets deleted due to expiration
+
+    Usage example:
+
+        from nameko_rediskn import rediskn
+
+
+        class MyService:
+
+            name = 'my-service'
+
+            @rediskn.subscribe(keys='foo/bar-*')
+            def subscriber(self, message):
+                event_type = message['data']
+                if event_type != 'expired':
+                    return
+
+                key = message['channel'].split(':')[1]
+
+                # ...
+    """
+
+    def __init__(self, events=None, keys=None, dbs=None, **kwargs):
+        """Initialize the notification events settings.
+
+        Args:
+            events (str or list(str)): One or more events to subscribe to
+            keys (str or list(str)): One or more keys to subscribe to
+            dbs (str or list(str)): One or more redis dbs to subscribe to
+        """
+        if events is None:
+            self.events = []
+        else:
+            self.events = _to_list(events)
+
+        if keys is None:
+            self.keys = []
+        else:
+            self.keys = _to_list(keys)
+
+        if not self.events and not self.keys:
+            raise RuntimeError(
+                'Provide either `events` or `keys` to get notifications'
+            )
+
+        if dbs is None:
+            self.dbs = None
+        else:
+            self.dbs = _to_list(dbs)
+
+        self.client = None
+        self._thread = None
+
+        super().__init__(**kwargs)
+
+    def setup(self):
+        # TODO: find a better way to expose the redis URL without
+        # harcoding 'session'
+        self._redis_uri = self.container.config['REDIS_URIS']['session']
+        # This should ideally be set in redis.conf
+        self._notification_events = self.container.config.get(
+            'REDIS_NOTIFICATION_EVENTS'
+        )
+
+        super().setup()
+
+    def start(self):
+        self._thread = self.container.spawn_managed_thread(self._run)
+
+        super().start()
+
+    def stop(self):
+        if self._thread is not None:
+            self._thread.kill()
+            self._thread = None
+        self.client = None
+
+        super().stop()
+
+    def kill(self):
+        if self._thread is not None:
+            self._thread.kill()
+            self._thread = None
+        self.client = None
+
+        super().kill()
+
+    def _run(self):
+        """Run the main loop which listens for subscription events.
+
+        When an event is received, the decorated method is called with a
+        single argument, the received message, which is a dictionary with the
+        following data:
+
+        `data`: the key for `keyevent` notifications or the event for
+                `keyspace` notifications
+
+        `type`: "pmessage" for simple events, "psubscribe" for subscription
+                events (subscription events are received when the entrypoint
+                initializes)
+        `pattern`: The subscription pattern
+
+        `channel`: The subscription channel
+
+        The subscription channel has the following format:
+
+            __<subscription type>@<db>__:<event suffix>
+
+        `db` is the redis database the event comes from. If the subscription
+        type is `keyevent`, then the event suffix is the event type (set, hset,
+        expire etc.). If the subscription type is `keyspace`, then the event
+        suffix is the key for which the event happened.
+        """
+        self._create_client()
+        pubsub = self._subscribe()
+
+        log.info('Started listening to redis keyspace notifications')
+
+        try:
+            for message in pubsub.listen():
+                self.container.spawn_worker(self, [message], {})
+        finally:
+            pubsub.close()
+            log.info('Stopped listening to redis keyspace notifications')
+
+    def _create_client(self):
+        client = StrictRedis.from_url(self._redis_uri, **REDIS_OPTIONS)
+
+        if self.dbs is None:
+            # Use the actual connected DB if no DBs have been provided
+            connected_db = client.connection_pool.connection_kwargs['db']
+            self.dbs = [connected_db]
+
+        if self._notification_events is not None:
+            client.config_set(
+                NOTIFICATIONS_SETTING_KEY,
+                self._notification_events
+            )
+
+        self.client = client
+
+    def _subscribe(self):
+        pubsub = self.client.pubsub()
+
+        keyevent_patterns = (
+            KEYEVENT_TEMPLATE.format(db=db, event=event)
+            for db in self.dbs
+            for event in self.events
+        )
+
+        keyspace_patterns = (
+            KEYSPACE_TEMPLATE.format(db=db, key=key)
+            for db in self.dbs
+            for key in self.keys
+        )
+
+        for pattern in chain(keyevent_patterns, keyspace_patterns):
+            pubsub.psubscribe(pattern)
+
+        return pubsub
+
+
+def _to_list(arg):
+    if isinstance(arg, tuple):
+        return list(arg)
+    if not isinstance(arg, list):
+        return [arg]
+    return arg
+
+
+subscribe = RedisKNEntrypoint.decorator

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -20,7 +20,7 @@ To enable them, a non-empty string must be used. The set of allowed characters
 can be found in the Redis keyspace notifications documentation.
 
 NOTE: it is recomended to set this parameter on the server side (`redis.conf`),
-as setting it in one of the clients (via the CONFIG SET) also affects the rest
+as setting it in one of the clients (via CONFIG SET) also affects the rest
 of them.
 """
 

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -109,7 +109,6 @@ class RedisKNEntrypoint(Entrypoint):
 
         self.client = None
         self._thread = None
-
         super().__init__(**kwargs)
 
     def setup(self):
@@ -125,7 +124,6 @@ class RedisKNEntrypoint(Entrypoint):
 
     def start(self):
         self._thread = self.container.spawn_managed_thread(self._run)
-
         super().start()
 
     def stop(self):
@@ -133,7 +131,6 @@ class RedisKNEntrypoint(Entrypoint):
             self._thread.kill()
             self._thread = None
         self.client = None
-
         super().stop()
 
     def kill(self):
@@ -141,7 +138,6 @@ class RedisKNEntrypoint(Entrypoint):
             self._thread.kill()
             self._thread = None
         self.client = None
-
         super().kill()
 
     def _run(self):
@@ -192,8 +188,7 @@ class RedisKNEntrypoint(Entrypoint):
 
         if self._notification_events is not None:
             client.config_set(
-                NOTIFICATIONS_SETTING_KEY,
-                self._notification_events
+                NOTIFICATIONS_SETTING_KEY, self._notification_events
             )
 
         self.client = client

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -193,14 +193,14 @@ class RedisKNEntrypoint(Entrypoint):
         self._create_client()
         pubsub = self._subscribe()
 
-        log.info('Started listening to redis keyspace notifications')
+        log.info('Started listening to Redis keyspace notifications')
 
         try:
             for message in pubsub.listen():
                 self.container.spawn_worker(self, [message], {})
         finally:
             pubsub.close()
-            log.info('Stopped listening to redis keyspace notifications')
+            log.info('Stopped listening to Redis keyspace notifications')
 
     def _create_client(self):
         client = StrictRedis.from_url(self._redis_uri, **REDIS_OPTIONS)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url='https://github.com/sohonetlabs/nameko-rediskn',
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=[
-        'nameko>=2.11',
+        'nameko>=2.6',
         'redis>=2.10.5',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,7 @@ setup(
     author_email='julio.trigo@sohonet.com',
     url='https://github.com/sohonetlabs/nameko-rediskn',
     packages=find_packages(exclude=['test', 'test.*']),
-    install_requires=[
-        'nameko>=2.6',
-        'redis>=2.10.5',
-    ],
+    install_requires=['nameko>=2.6', 'redis>=2.10.5'],
     extras_require={
         'dev': [
             'pytest==4.3.1',

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     extras_require={
         'dev': [
             'pytest==4.3.1',
+            'coverage==4.5.3',
             'flake8',
-            'coverage',
             'restructuredtext-lint',
             'Pygments',
         ],

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     install_requires=['nameko>=2.6', 'redis>=2.10.5'],
     extras_require={
         'dev': [
-            'pytest==4.4.0',
-            'coverage==4.5.3',
+            'pytest~=5.0.0',
+            'coverage~=4.5.3',
             'flake8',
             'restructuredtext-lint',
             'Pygments',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,51 @@
+import os
+from codecs import open
+from setuptools import setup, find_packages
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(here, 'README.rst'), 'r', 'utf-8') as handle:
+    readme = handle.read()
+
+setup(
+    name='nameko-rediskn',
+    version='0.1.0',
+    description='Nameko Redis Keyspace Notifications extension.',
+    long_description=readme,
+    long_description_content_type='text/x-rst',
+    author='Julio Trigo',
+    author_email='julio.trigo@sohonet.com',
+    url='https://github.com/sohonetlabs/nameko-rediskn',
+    packages=find_packages(exclude=['test', 'test.*']),
+    install_requires=[
+        'nameko>=2.11',
+        'redis>=2.10.5',
+    ],
+    extras_require={
+        'dev': [
+            'pytest==4.3.1',
+            'flake8',
+            'coverage',
+            'restructuredtext-lint',
+            'Pygments',
+        ],
+    },
+    zip_safe=True,
+    license='MIT License',
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Database",
+        "Topic :: Database :: Front-Ends",
+        "Topic :: Internet",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=['nameko>=2.6', 'redis>=2.10.5'],
     extras_require={
         'dev': [
-            'pytest==4.3.1',
+            'pytest==4.4.0',
             'coverage==4.5.3',
             'flake8',
             'restructuredtext-lint',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,4 @@
+from unittest import TestCase
+
+
+assert_items_equal = TestCase().assertCountEqual

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,8 @@
 from unittest import TestCase
 
 
+URI_CONFIG_KEY = 'TEST_KEY'
+REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
+
+
 assert_items_equal = TestCase().assertCountEqual

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
+TIME_SLEEP = 0.1
 URI_CONFIG_KEY = 'TEST_KEY'
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
 
-URI_CONFIG_KEY = 'TEST_KEY'
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
+URI_CONFIG_KEY = 'TEST_KEY'
 
 
 assert_items_equal = TestCase().assertCountEqual

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,7 +10,7 @@ from test import REDIS_OPTIONS, TIME_SLEEP, URI_CONFIG_KEY
 
 
 @pytest.fixture
-def redis_config():
+def config():
     return {
         'REDIS': {'NOTIFICATION_EVENTS': 'KEA'},
         'REDIS_URIS': {URI_CONFIG_KEY: "redis://localhost:6379/0"},
@@ -18,15 +18,8 @@ def redis_config():
 
 
 @pytest.fixture
-def config(rabbit_config, redis_config):
-    config = rabbit_config.copy()
-    config.update(redis_config)
-    return config
-
-
-@pytest.fixture
-def redis(redis_config):
-    redis_uri = redis_config['REDIS_URIS'][URI_CONFIG_KEY]
+def redis(config):
+    redis_uri = config['REDIS_URIS'][URI_CONFIG_KEY]
     client = StrictRedis.from_url(redis_uri, **REDIS_OPTIONS)
     client.flushall()
     yield client
@@ -34,10 +27,10 @@ def redis(redis_config):
 
 
 @pytest.fixture
-def redis_db_1(redis_config):
+def redis_db_1(config):
     # url argument takes precedence over db in the url
     redis_uri = '{}?db=1'.format(
-        redis_config['REDIS_URIS'][URI_CONFIG_KEY]
+        config['REDIS_URIS'][URI_CONFIG_KEY]
     )
     client = StrictRedis.from_url(redis_uri, db=1, **REDIS_OPTIONS)
     client.flushall()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,28 @@
 import pytest
+from redis import StrictRedis
+
+from test import URI_CONFIG_KEY, REDIS_OPTIONS
 
 
 @pytest.fixture
-def config(rabbit_config):
-    config = {
-        'REDIS_NOTIFICATION_EVENTS': 'KEA',
-        'REDIS_URIS': {'session': "redis://localhost:6379/0"},
+def redis_config():
+    return {
+        'REDIS': {'NOTIFICATION_EVENTS': 'KEA'},
+        'REDIS_URIS': {URI_CONFIG_KEY: "redis://localhost:6379/0"},
     }
-    config.update()
+
+
+@pytest.fixture
+def config(rabbit_config, redis_config):
+    config = rabbit_config.copy()
+    config.update(redis_config)
     return config
+
+
+@pytest.fixture
+def redis(redis_config):
+    redis_uri = redis_config['REDIS_URIS'][URI_CONFIG_KEY]
+    client = StrictRedis.from_url(redis_uri, **REDIS_OPTIONS)
+    client.flushall()
+    yield client
+    client.flushall()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def config(rabbit_config):
+    config = {
+        'REDIS_NOTIFICATION_EVENTS': 'KEA',
+        'REDIS_URIS': {'session': "redis://localhost:6379/0"},
+    }
+    config.update()
+    return config

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,7 +12,7 @@ from test import REDIS_OPTIONS, TIME_SLEEP, URI_CONFIG_KEY
 @pytest.fixture
 def config():
     return {
-        'REDIS': {'NOTIFICATION_EVENTS': 'KEA'},
+        'REDIS': {'notification_events': 'KEA'},
         'REDIS_URIS': {URI_CONFIG_KEY: "redis://localhost:6379/0"},
     }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from redis import StrictRedis
 
-from test import URI_CONFIG_KEY, REDIS_OPTIONS
+from test import REDIS_OPTIONS, URI_CONFIG_KEY
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from eventlet import sleep
@@ -69,3 +69,9 @@ def create_service(container_factory, config, tracker):
         return ServiceMeta(container)
 
     return create
+
+
+@pytest.fixture
+def log_mock():
+    with patch('nameko_rediskn.rediskn.log') as log_mock:
+        yield log_mock

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -384,7 +384,7 @@ class TestListenAll:
         )
 
     @pytest.mark.parametrize(
-        'action, ttl, wait_time', [('expire', 1, 1.1), ('pexpire', 100, 0.2)]
+        'action, ttl, wait_time', [('expire', 1, 1.1), ('pexpire', 1000, 1.1)]
     )
     @pytest.mark.usefixtures('service')
     def test_expire(self, tracker, redis, action, ttl, wait_time):

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -33,7 +33,7 @@ class TestConfig:
     def test_uses_notification_events_config_if_provided(
         self, create_service, config
     ):
-        config['REDIS']['NOTIFICATION_EVENTS'] = 'TEST_VALUE'
+        config['REDIS']['notification_events'] = 'test_value'
 
         with patch('nameko_rediskn.rediskn.StrictRedis') as strict_redis_mock:
             create_service(
@@ -41,13 +41,13 @@ class TestConfig:
             )
             redis_mock = strict_redis_mock.from_url.return_value
             assert redis_mock.config_set.call_args_list == [
-                call('notify-keyspace-events', 'TEST_VALUE')
+                call('notify-keyspace-events', 'test_value')
             ]
 
     def test_does_not_use_notification_events_config_if_not_provided(
         self, create_service, config
     ):
-        config['REDIS'].pop('NOTIFICATION_EVENTS')
+        config['REDIS'].pop('notification_events')
 
         with patch('nameko_rediskn.rediskn.StrictRedis') as strict_redis_mock:
             create_service(

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -1,0 +1,504 @@
+from time import sleep
+from collections import namedtuple
+from unittest.mock import call, patch, Mock, MagicMock
+
+from redis import StrictRedis
+import pytest
+
+from nameko_rediskn import rediskn
+from test import assert_items_equal
+
+
+TIME_SLEEP = 0.1
+
+
+@pytest.fixture
+def tracker():
+    yield Mock()
+
+
+@pytest.fixture
+def create_service(container_factory, config, tracker):
+    def create(**kwargs):
+        class DummyService:
+
+            name = 'dummy_service'
+
+            @rediskn.subscribe(**kwargs)
+            def handler(self, message):
+                tracker.run(message)
+
+        ServiceMeta = namedtuple('ServiceMeta', ['container'])
+        container = container_factory(DummyService, config)
+
+        container.start()
+        sleep(TIME_SLEEP)
+        return ServiceMeta(container)
+
+    return create
+
+
+@pytest.fixture
+def create_dummy_service(create_service):
+
+    def _create_dummy_service(**kwargs):
+        return create_service(**kwargs)
+
+    return _create_dummy_service
+
+
+@pytest.fixture
+def redis(config):
+    redis_uri = config['REDIS_URIS']['session']
+    client = StrictRedis.from_url(redis_uri)
+    client.flushall()
+    return client
+
+
+class TestRedisNotifierSetup:
+
+    @pytest.fixture
+    def service(self, create_dummy_service):
+        return create_dummy_service(events='*', keys='*', dbs='*')
+
+    def test_raises_if_wrong_arguments(self, create_dummy_service):
+        with pytest.raises(RuntimeError):
+            create_dummy_service()
+
+        with pytest.raises(RuntimeError):
+            create_dummy_service(dbs=[1])
+
+    def test_container_stop(self, create_dummy_service):
+        with patch(
+            'nameko.containers.ServiceContainer.spawn_managed_thread'
+        ) as spawn_managed_thread:
+            thread_mock = MagicMock()
+            thread_mock.kill.return_value = MagicMock()
+            spawn_managed_thread.return_value = thread_mock
+            service = create_dummy_service(events='*')
+            service.container.stop()
+
+        assert thread_mock.kill.call_args_list == [call()]
+
+        entrypoint = next(iter(service.container.entrypoints))
+        assert entrypoint._thread is None
+        assert entrypoint.client is None
+
+    def test_container_kill(self, create_dummy_service):
+        with patch(
+            'nameko.containers.ServiceContainer.spawn_managed_thread'
+        ) as spawn_managed_thread:
+            thread_mock = MagicMock()
+            thread_mock.kill.return_value = MagicMock()
+            spawn_managed_thread.return_value = thread_mock
+            service = create_dummy_service(events='*')
+            service.container.kill()
+
+        assert thread_mock.kill.call_args_list == [call()]
+
+        entrypoint = next(iter(service.container.entrypoints))
+        assert entrypoint._thread is None
+        assert entrypoint.client is None
+
+
+class TestListenAll:
+
+    @pytest.fixture
+    def service(self, create_dummy_service):
+        return create_dummy_service(events='*', keys='*', dbs='*')
+
+    @pytest.mark.usefixtures('service')
+    def test_subscribe_events(self, tracker, redis):
+        assert tracker.run.call_args_list == [
+            call({
+                'data': 1,
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyevent@*__:*'
+            }),
+            call({
+                'data': 2,
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyspace@*__:*'
+            }),
+        ]
+
+    @pytest.mark.parametrize('action,args,event_type', [
+        ('set', ('foo', 'bar'), 'set'),
+        ('hset', ('foo', 'bar', 'baz'), 'hset'),
+        ('hmset', ('foo', {'bar': 'baz'}), 'hset'),
+    ])
+    @pytest.mark.usefixtures('service')
+    def test_simple_events(self, tracker, redis, action, args, event_type):
+        method = getattr(redis, action)
+        method(*args)
+        sleep(TIME_SLEEP)
+
+        key = args[0]
+
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@*__:*',
+                    'channel': '__keyspace@0__:{}'.format(key),
+                    'data': event_type,
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@*__:*',
+                    'channel': '__keyevent@0__:{}'.format(event_type),
+                    'data': key,
+                })
+            ]
+        )
+
+    @pytest.mark.usefixtures('service')
+    def test_del(self, tracker, redis):
+        redis.set('foo', 'bar')
+        redis.delete('foo')
+        sleep(TIME_SLEEP)
+
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@*__:*',
+                    'channel': '__keyspace@0__:foo',
+                    'data': 'del',
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@*__:*',
+                    'channel': '__keyevent@0__:del',
+                    'data': 'foo',
+                })
+            ]
+        )
+
+    @pytest.mark.parametrize('keys', [('one', ), ('one', 'two')])
+    @pytest.mark.usefixtures('service')
+    def test_hdel(self, tracker, redis, keys):
+        redis.hmset('foo', {'one': '1', 'two': '2', 'three': '3'})
+        redis.hdel('foo', *keys)
+        sleep(TIME_SLEEP)
+
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@*__:*',
+                    'channel': '__keyspace@0__:foo',
+                    'data': 'hdel',
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@*__:*',
+                    'channel': '__keyevent@0__:hdel',
+                    'data': 'foo',
+                })
+            ]
+        )
+
+    @pytest.mark.parametrize('action,ttl,wait_time', [
+        ('expire', 1, 1.1),
+        ('pexpire', 100, 0.2),
+    ])
+    @pytest.mark.usefixtures('service')
+    def test_expire(self, tracker, redis, action, ttl, wait_time):
+        redis.set('foo', 'bar')
+        method = getattr(redis, action)
+        method('foo', ttl)
+        sleep(TIME_SLEEP)
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@*__:*',
+                    'channel': '__keyspace@0__:foo',
+                    'data': 'expire',
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@*__:*',
+                    'channel': '__keyevent@0__:expire',
+                    'data': 'foo',
+                })
+            ]
+        )
+
+        sleep(wait_time)
+
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@*__:*',
+                    'channel': '__keyspace@0__:foo',
+                    'data': 'expired',
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@*__:*',
+                    'channel': '__keyevent@0__:expired',
+                    'data': 'foo',
+                })
+            ]
+        )
+
+
+class TestListenEvents:
+
+    def test_subscribe_events(self, create_dummy_service, tracker, redis):
+        create_dummy_service(events='psubscribe', dbs='*')
+        assert tracker.run.call_args_list == [
+            call({
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyevent@*__:psubscribe',
+                'data': 1,
+            })
+        ]
+
+    def test_listen_event(self, create_dummy_service, tracker, redis):
+        create_dummy_service(events='set', dbs='*')
+
+        redis.set('foo', 'bar')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list[-1] == call({
+            'type': 'pmessage',
+            'pattern': '__keyevent@*__:set',
+            'channel': '__keyevent@0__:set',
+            'data': 'foo',
+        })
+
+    @pytest.mark.parametrize('events', [['set', 'hset'], ('set', 'hset')])
+    def test_listen_multiple_events(
+        self, create_dummy_service, tracker, redis, events
+    ):
+        create_dummy_service(events=events, dbs='*')
+
+        redis.set('foo', 'bar')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list[-1] == call({
+            'type': 'pmessage',
+            'pattern': '__keyevent@*__:set',
+            'channel': '__keyevent@0__:set',
+            'data': 'foo',
+        })
+
+        redis.hset('one', 'two', 'three')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list[-1] == call({
+            'type': 'pmessage',
+            'pattern': '__keyevent@*__:hset',
+            'channel': '__keyevent@0__:hset',
+            'data': 'one',
+        })
+
+    def test_ignores_other_events(self, create_dummy_service, tracker, redis):
+        create_dummy_service(events='hset', dbs='*')
+        tracker.run.reset_mock()
+
+        redis.set('foo', 'bar')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list == []
+
+
+class TestListenKeys:
+
+    def test_subscribe_events(self, create_dummy_service, tracker, redis):
+        create_dummy_service(keys='foo', dbs='*')
+        assert tracker.run.call_args_list == [
+            call({
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyspace@*__:foo',
+                'data': 1,
+            })
+        ]
+
+    def test_listen_key(self, create_dummy_service, tracker, redis):
+        create_dummy_service(keys='foo', dbs='*')
+
+        redis.set('foo', 'bar')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list[-1] == call({
+            'type': 'pmessage',
+            'pattern': '__keyspace@*__:foo',
+            'channel': '__keyspace@0__:foo',
+            'data': 'set',
+        })
+
+    @pytest.mark.parametrize('keys', [['foo', 'bar'], ('foo', 'bar')])
+    def test_listen_multiple_keys(
+        self, create_dummy_service, tracker, redis, keys
+    ):
+        create_dummy_service(keys=keys, dbs='*')
+
+        redis.set('foo', '1')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list[-1] == call({
+            'type': 'pmessage',
+            'pattern': '__keyspace@*__:foo',
+            'channel': '__keyspace@0__:foo',
+            'data': 'set',
+        })
+
+        redis.set('bar', '2')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list[-1] == call({
+            'type': 'pmessage',
+            'pattern': '__keyspace@*__:bar',
+            'channel': '__keyspace@0__:bar',
+            'data': 'set',
+        })
+
+    def test_ignores_other_keys(self, create_dummy_service, tracker, redis):
+        create_dummy_service(keys='foo', dbs='*')
+        tracker.run.reset_mock()
+
+        redis.set('bar', '2')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list == []
+
+
+class TestListenDB:
+
+    @pytest.fixture
+    def redis_db_1(self, config):
+        # url argument takes precedence over db in the url
+        redis_uri = '{}?db=1'.format(config['REDIS_URIS']['session'])
+        client = StrictRedis.from_url(redis_uri, db=1)
+        client.flushall()
+        return client
+
+    def test_subscribes_to_db_from_uri(self, create_dummy_service, tracker):
+        create_dummy_service(keys='*', events='*')
+        assert tracker.run.call_args_list == [
+            call({
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyevent@0__:*',
+                'data': 1,
+            }),
+            call({
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyspace@0__:*',
+                'data': 2,
+            }),
+        ]
+
+    def test_subscribe_events(self, create_dummy_service, tracker):
+        create_dummy_service(keys='*', events='*', dbs=1)
+        assert tracker.run.call_args_list == [
+            call({
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyevent@1__:*',
+                'data': 1,
+            }),
+            call({
+                'type': 'psubscribe',
+                'pattern': None,
+                'channel': '__keyspace@1__:*',
+                'data': 2,
+            }),
+        ]
+
+    def test_listen_db(self, create_dummy_service, tracker, redis_db_1):
+        create_dummy_service(keys='*', events='*', dbs=1)
+
+        redis_db_1.set('foo', 'bar')
+        sleep(TIME_SLEEP)
+
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@1__:*',
+                    'channel': '__keyspace@1__:foo',
+                    'data': 'set',
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@1__:*',
+                    'channel': '__keyevent@1__:set',
+                    'data': 'foo',
+                })
+            ]
+        )
+
+    def test_listen_multiple_dbs(
+        self, create_dummy_service, tracker, redis, redis_db_1
+    ):
+        create_dummy_service(keys='*', events='*', dbs=[0, 1])
+
+        redis.set('foo', '1')
+        sleep(TIME_SLEEP)
+
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@0__:*',
+                    'channel': '__keyspace@0__:foo',
+                    'data': 'set',
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@0__:*',
+                    'channel': '__keyevent@0__:set',
+                    'data': 'foo',
+                })
+            ]
+        )
+
+        redis_db_1.set('bar', '2')
+        sleep(TIME_SLEEP)
+
+        assert_items_equal(
+            tracker.run.call_args_list[-2:],
+            [
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@1__:*',
+                    'channel': '__keyspace@1__:bar',
+                    'data': 'set',
+                }),
+                call({
+                    'type': 'pmessage',
+                    'pattern': '__keyevent@1__:*',
+                    'channel': '__keyevent@1__:set',
+                    'data': 'bar',
+                })
+            ]
+        )
+
+    def test_ignores_other_dbs(
+        self, create_dummy_service, tracker, redis_db_1
+    ):
+        create_dummy_service(keys='*', events='*', dbs=0)
+        tracker.run.reset_mock()
+
+        redis_db_1.set('foo', 'bar')
+        sleep(TIME_SLEEP)
+
+        assert tracker.run.call_args_list == []

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -40,7 +40,6 @@ def create_service(container_factory, config, tracker):
 
 @pytest.fixture
 def create_dummy_service(create_service):
-
     def _create_dummy_service(**kwargs):
         return create_service(**kwargs)
 

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -46,8 +46,11 @@ class TestConfig:
 
         with pytest.raises(KeyError) as exc:
             create_service(
-                config=config, uri_config_key=URI_CONFIG_KEY, events='*',
-                keys='*', dbs='*'
+                config=config,
+                uri_config_key=URI_CONFIG_KEY,
+                events='*',
+                keys='*',
+                dbs='*',
             )
 
         assert exc.value.args[0] == 'TEST_KEY'
@@ -105,9 +108,7 @@ class TestContainerStop:
             thread_mock = MagicMock()
             thread_mock.kill.return_value = MagicMock()
             spawn_managed_thread.return_value = thread_mock
-            service = create_service(
-                uri_config_key=URI_CONFIG_KEY, events='*'
-            )
+            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
             service.container.stop()
 
         assert thread_mock.kill.call_args_list == [call()]
@@ -123,9 +124,7 @@ class TestContainerStop:
             thread_mock = MagicMock()
             thread_mock.kill.return_value = MagicMock()
             spawn_managed_thread.return_value = None
-            service = create_service(
-                uri_config_key=URI_CONFIG_KEY, events='*'
-            )
+            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
             service.container.stop()
 
         assert thread_mock.kill.call_args_list == []
@@ -144,9 +143,7 @@ class TestContainerKill:
             thread_mock = MagicMock()
             thread_mock.kill.return_value = MagicMock()
             spawn_managed_thread.return_value = thread_mock
-            service = create_service(
-                uri_config_key=URI_CONFIG_KEY, events='*'
-            )
+            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
             service.container.kill()
 
         assert thread_mock.kill.call_args_list == [call()]
@@ -162,9 +159,7 @@ class TestContainerKill:
             thread_mock = MagicMock()
             thread_mock.kill.return_value = MagicMock()
             spawn_managed_thread.return_value = None
-            service = create_service(
-                uri_config_key=URI_CONFIG_KEY, events='*'
-            )
+            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
             service.container.kill()
 
         assert thread_mock.kill.call_args_list == []
@@ -185,25 +180,32 @@ class TestListenAll:
     @pytest.mark.usefixtures('service')
     def test_subscribe_events(self, tracker, redis):
         assert tracker.run.call_args_list == [
-            call({
-                'data': 1,
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyevent@*__:*'
-            }),
-            call({
-                'data': 2,
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyspace@*__:*'
-            }),
+            call(
+                {
+                    'data': 1,
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyevent@*__:*',
+                }
+            ),
+            call(
+                {
+                    'data': 2,
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyspace@*__:*',
+                }
+            ),
         ]
 
-    @pytest.mark.parametrize('action,args,event_type', [
-        ('set', ('foo', 'bar'), 'set'),
-        ('hset', ('foo', 'bar', 'baz'), 'hset'),
-        ('hmset', ('foo', {'bar': 'baz'}), 'hset'),
-    ])
+    @pytest.mark.parametrize(
+        'action,args,event_type',
+        [
+            ('set', ('foo', 'bar'), 'set'),
+            ('hset', ('foo', 'bar', 'baz'), 'hset'),
+            ('hmset', ('foo', {'bar': 'baz'}), 'hset'),
+        ],
+    )
     @pytest.mark.usefixtures('service')
     def test_simple_events(self, tracker, redis, action, args, event_type):
         method = getattr(redis, action)
@@ -215,19 +217,23 @@ class TestListenAll:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@*__:*',
-                    'channel': '__keyspace@0__:{}'.format(key),
-                    'data': event_type,
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@*__:*',
-                    'channel': '__keyevent@0__:{}'.format(event_type),
-                    'data': key,
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@*__:*',
+                        'channel': '__keyspace@0__:{}'.format(key),
+                        'data': event_type,
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@*__:*',
+                        'channel': '__keyevent@0__:{}'.format(event_type),
+                        'data': key,
+                    }
+                ),
+            ],
         )
 
     @pytest.mark.usefixtures('service')
@@ -239,22 +245,26 @@ class TestListenAll:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@*__:*',
-                    'channel': '__keyspace@0__:foo',
-                    'data': 'del',
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@*__:*',
-                    'channel': '__keyevent@0__:del',
-                    'data': 'foo',
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@*__:*',
+                        'channel': '__keyspace@0__:foo',
+                        'data': 'del',
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@*__:*',
+                        'channel': '__keyevent@0__:del',
+                        'data': 'foo',
+                    }
+                ),
+            ],
         )
 
-    @pytest.mark.parametrize('keys', [('one', ), ('one', 'two')])
+    @pytest.mark.parametrize('keys', [('one',), ('one', 'two')])
     @pytest.mark.usefixtures('service')
     def test_hdel(self, tracker, redis, keys):
         redis.hmset('foo', {'one': '1', 'two': '2', 'three': '3'})
@@ -264,25 +274,28 @@ class TestListenAll:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@*__:*',
-                    'channel': '__keyspace@0__:foo',
-                    'data': 'hdel',
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@*__:*',
-                    'channel': '__keyevent@0__:hdel',
-                    'data': 'foo',
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@*__:*',
+                        'channel': '__keyspace@0__:foo',
+                        'data': 'hdel',
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@*__:*',
+                        'channel': '__keyevent@0__:hdel',
+                        'data': 'foo',
+                    }
+                ),
+            ],
         )
 
-    @pytest.mark.parametrize('action,ttl,wait_time', [
-        ('expire', 1, 1.1),
-        ('pexpire', 100, 0.2),
-    ])
+    @pytest.mark.parametrize(
+        'action,ttl,wait_time', [('expire', 1, 1.1), ('pexpire', 100, 0.2)]
+    )
     @pytest.mark.usefixtures('service')
     def test_expire(self, tracker, redis, action, ttl, wait_time):
         redis.set('foo', 'bar')
@@ -292,19 +305,23 @@ class TestListenAll:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@*__:*',
-                    'channel': '__keyspace@0__:foo',
-                    'data': 'expire',
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@*__:*',
-                    'channel': '__keyevent@0__:expire',
-                    'data': 'foo',
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@*__:*',
+                        'channel': '__keyspace@0__:foo',
+                        'data': 'expire',
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@*__:*',
+                        'channel': '__keyevent@0__:expire',
+                        'data': 'foo',
+                    }
+                ),
+            ],
         )
 
         sleep(wait_time)
@@ -312,19 +329,23 @@ class TestListenAll:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@*__:*',
-                    'channel': '__keyspace@0__:foo',
-                    'data': 'expired',
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@*__:*',
-                    'channel': '__keyevent@0__:expired',
-                    'data': 'foo',
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@*__:*',
+                        'channel': '__keyspace@0__:foo',
+                        'data': 'expired',
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@*__:*',
+                        'channel': '__keyevent@0__:expired',
+                        'data': 'foo',
+                    }
+                ),
+            ],
         )
 
 
@@ -335,61 +356,63 @@ class TestListenEvents:
             uri_config_key=URI_CONFIG_KEY, events='psubscribe', dbs='*'
         )
         assert tracker.run.call_args_list == [
-            call({
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyevent@*__:psubscribe',
-                'data': 1,
-            })
+            call(
+                {
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyevent@*__:psubscribe',
+                    'data': 1,
+                }
+            )
         ]
 
     def test_listen_event(self, create_service, tracker, redis):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, events='set', dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, events='set', dbs='*')
 
         redis.set('foo', 'bar')
         sleep(TIME_SLEEP)
 
-        assert tracker.run.call_args_list[-1] == call({
-            'type': 'pmessage',
-            'pattern': '__keyevent@*__:set',
-            'channel': '__keyevent@0__:set',
-            'data': 'foo',
-        })
+        assert tracker.run.call_args_list[-1] == call(
+            {
+                'type': 'pmessage',
+                'pattern': '__keyevent@*__:set',
+                'channel': '__keyevent@0__:set',
+                'data': 'foo',
+            }
+        )
 
     @pytest.mark.parametrize('events', [['set', 'hset'], ('set', 'hset')])
     def test_listen_multiple_events(
         self, create_service, tracker, redis, events
     ):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, events=events, dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, events=events, dbs='*')
 
         redis.set('foo', 'bar')
         sleep(TIME_SLEEP)
 
-        assert tracker.run.call_args_list[-1] == call({
-            'type': 'pmessage',
-            'pattern': '__keyevent@*__:set',
-            'channel': '__keyevent@0__:set',
-            'data': 'foo',
-        })
+        assert tracker.run.call_args_list[-1] == call(
+            {
+                'type': 'pmessage',
+                'pattern': '__keyevent@*__:set',
+                'channel': '__keyevent@0__:set',
+                'data': 'foo',
+            }
+        )
 
         redis.hset('one', 'two', 'three')
         sleep(TIME_SLEEP)
 
-        assert tracker.run.call_args_list[-1] == call({
-            'type': 'pmessage',
-            'pattern': '__keyevent@*__:hset',
-            'channel': '__keyevent@0__:hset',
-            'data': 'one',
-        })
+        assert tracker.run.call_args_list[-1] == call(
+            {
+                'type': 'pmessage',
+                'pattern': '__keyevent@*__:hset',
+                'channel': '__keyevent@0__:hset',
+                'data': 'one',
+            }
+        )
 
     def test_ignores_other_events(self, create_service, tracker, redis):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, events='hset', dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, events='hset', dbs='*')
         tracker.run.reset_mock()
 
         redis.set('foo', 'bar')
@@ -401,63 +424,63 @@ class TestListenEvents:
 class TestListenKeys:
 
     def test_subscribe_events(self, create_service, tracker, redis):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*')
         assert tracker.run.call_args_list == [
-            call({
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyspace@*__:foo',
-                'data': 1,
-            })
+            call(
+                {
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyspace@*__:foo',
+                    'data': 1,
+                }
+            )
         ]
 
     def test_listen_key(self, create_service, tracker, redis):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*')
 
         redis.set('foo', 'bar')
         sleep(TIME_SLEEP)
 
-        assert tracker.run.call_args_list[-1] == call({
-            'type': 'pmessage',
-            'pattern': '__keyspace@*__:foo',
-            'channel': '__keyspace@0__:foo',
-            'data': 'set',
-        })
+        assert tracker.run.call_args_list[-1] == call(
+            {
+                'type': 'pmessage',
+                'pattern': '__keyspace@*__:foo',
+                'channel': '__keyspace@0__:foo',
+                'data': 'set',
+            }
+        )
 
     @pytest.mark.parametrize('keys', [['foo', 'bar'], ('foo', 'bar')])
     def test_listen_multiple_keys(self, create_service, tracker, redis, keys):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys=keys, dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys=keys, dbs='*')
 
         redis.set('foo', '1')
         sleep(TIME_SLEEP)
 
-        assert tracker.run.call_args_list[-1] == call({
-            'type': 'pmessage',
-            'pattern': '__keyspace@*__:foo',
-            'channel': '__keyspace@0__:foo',
-            'data': 'set',
-        })
+        assert tracker.run.call_args_list[-1] == call(
+            {
+                'type': 'pmessage',
+                'pattern': '__keyspace@*__:foo',
+                'channel': '__keyspace@0__:foo',
+                'data': 'set',
+            }
+        )
 
         redis.set('bar', '2')
         sleep(TIME_SLEEP)
 
-        assert tracker.run.call_args_list[-1] == call({
-            'type': 'pmessage',
-            'pattern': '__keyspace@*__:bar',
-            'channel': '__keyspace@0__:bar',
-            'data': 'set',
-        })
+        assert tracker.run.call_args_list[-1] == call(
+            {
+                'type': 'pmessage',
+                'pattern': '__keyspace@*__:bar',
+                'channel': '__keyspace@0__:bar',
+                'data': 'set',
+            }
+        )
 
     def test_ignores_other_keys(self, create_service, tracker, redis):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*')
         tracker.run.reset_mock()
 
         redis.set('bar', '2')
@@ -479,22 +502,24 @@ class TestListenDB:
         return client
 
     def test_subscribes_to_db_from_uri(self, create_service, tracker):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='*', events='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='*', events='*')
         assert tracker.run.call_args_list == [
-            call({
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyevent@0__:*',
-                'data': 1,
-            }),
-            call({
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyspace@0__:*',
-                'data': 2,
-            }),
+            call(
+                {
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyevent@0__:*',
+                    'data': 1,
+                }
+            ),
+            call(
+                {
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyspace@0__:*',
+                    'data': 2,
+                }
+            ),
         ]
 
     def test_subscribe_events(self, create_service, tracker):
@@ -502,18 +527,22 @@ class TestListenDB:
             uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=1
         )
         assert tracker.run.call_args_list == [
-            call({
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyevent@1__:*',
-                'data': 1,
-            }),
-            call({
-                'type': 'psubscribe',
-                'pattern': None,
-                'channel': '__keyspace@1__:*',
-                'data': 2,
-            }),
+            call(
+                {
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyevent@1__:*',
+                    'data': 1,
+                }
+            ),
+            call(
+                {
+                    'type': 'psubscribe',
+                    'pattern': None,
+                    'channel': '__keyspace@1__:*',
+                    'data': 2,
+                }
+            ),
         ]
 
     def test_listen_db(self, create_service, tracker, redis_db_1):
@@ -527,19 +556,23 @@ class TestListenDB:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@1__:*',
-                    'channel': '__keyspace@1__:foo',
-                    'data': 'set',
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@1__:*',
-                    'channel': '__keyevent@1__:set',
-                    'data': 'foo',
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@1__:*',
+                        'channel': '__keyspace@1__:foo',
+                        'data': 'set',
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@1__:*',
+                        'channel': '__keyevent@1__:set',
+                        'data': 'foo',
+                    }
+                ),
+            ],
         )
 
     def test_listen_multiple_dbs(
@@ -555,19 +588,23 @@ class TestListenDB:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@0__:*',
-                    'channel': '__keyspace@0__:foo',
-                    'data': 'set',
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@0__:*',
-                    'channel': '__keyevent@0__:set',
-                    'data': 'foo',
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@0__:*',
+                        'channel': '__keyspace@0__:foo',
+                        'data': 'set',
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@0__:*',
+                        'channel': '__keyevent@0__:set',
+                        'data': 'foo',
+                    }
+                ),
+            ],
         )
 
         redis_db_1.set('bar', '2')
@@ -576,19 +613,23 @@ class TestListenDB:
         assert_items_equal(
             tracker.run.call_args_list[-2:],
             [
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyspace@1__:*',
-                    'channel': '__keyspace@1__:bar',
-                    'data': 'set',
-                }),
-                call({
-                    'type': 'pmessage',
-                    'pattern': '__keyevent@1__:*',
-                    'channel': '__keyevent@1__:set',
-                    'data': 'bar',
-                })
-            ]
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyspace@1__:*',
+                        'channel': '__keyspace@1__:bar',
+                        'data': 'set',
+                    }
+                ),
+                call(
+                    {
+                        'type': 'pmessage',
+                        'pattern': '__keyevent@1__:*',
+                        'channel': '__keyevent@1__:set',
+                        'data': 'bar',
+                    }
+                ),
+            ],
         )
 
     def test_ignores_other_dbs(self, create_service, tracker, redis_db_1):

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -185,7 +185,7 @@ class TestListenAll:
         )
 
     @pytest.mark.usefixtures('service')
-    def test_subscribe_events(self, tracker, redis):
+    def test_subscribe_events(self, tracker):
         assert_items_equal(
             tracker.call_args_list,
             [
@@ -473,7 +473,7 @@ class TestListenAll:
 
 class TestListenEvents:
 
-    def test_subscribe_events(self, create_service, tracker, redis):
+    def test_subscribe_events(self, create_service, tracker):
         create_service(
             uri_config_key=URI_CONFIG_KEY, events='psubscribe', dbs='*'
         )
@@ -580,7 +580,7 @@ class TestListenEvents:
 
 class TestListenKeys:
 
-    def test_subscribe_events(self, create_service, tracker, redis):
+    def test_subscribe_events(self, create_service, tracker):
         create_service(uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*')
         assert tracker.call_args_list == [
             call(

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -4,7 +4,14 @@ import pytest
 from eventlet import sleep
 from nameko.exceptions import ConfigurationError
 
+from nameko_rediskn import REDIS_PMESSAGE_TYPE
 from test import assert_items_equal, TIME_SLEEP, URI_CONFIG_KEY
+
+
+class TestPublicConstants:
+
+    def test_value(self):
+        assert REDIS_PMESSAGE_TYPE == 'pmessage'
 
 
 class TestConfig:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34,py35,py36,py37}-nameko{2.11,2.12,latest}
+envlist = {py34,py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}
 skipsdist = True
 
 [testenv]
@@ -9,5 +9,9 @@ extras = dev
 deps =
     nameko2.11: nameko>=2.11,<2.12
     nameko2.12: nameko>=2.12,<2.13
+    redis2.10: redis>=2.10,<2.11
+    redis3.0: redis>=3.0,<3.1
+    redis3.1: redis>=3.1,<3.2
+    redis3.2: redis>=3.2,<3.3
 commands =
     make coverage ARGS='-vv'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34,py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}
+envlist = {py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = {py34,py35,py36,py37}
+skipsdist = True
+
+[testenv]
+whitelist_externals = make
+usedevelop = true
+extras = dev
+commands =
+    make coverage ARGS='-vv'

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,13 @@
 [tox]
-envlist = {py34,py35,py36,py37}
+envlist = {py34,py35,py36,py37}-nameko{2.11,2.12,latest}
 skipsdist = True
 
 [testenv]
 whitelist_externals = make
 usedevelop = true
 extras = dev
+deps =
+    nameko2.11: nameko>=2.11,<2.12
+    nameko2.12: nameko>=2.12,<2.13
 commands =
     make coverage ARGS='-vv'


### PR DESCRIPTION
* Initial implementation of the library:
  - Add the ability to subscribe to events
  - Add the ability to subscribe to keys
  - Add the ability to subscribe to databases
* Add support for Python ``3.5``, ``3.6``, ``3.7``
* Add support for Nameko ``2.11``, ``2.12``, ``3.0``
* Add support for (Python) Redis ``2.10``, ``3.0``, ``3.1``, ``3.2``
* Add support for Redis ``4.0``
* CI pipeline
* Documentation