### PR TITLE
Add separate linting stage and Black/isort formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Temporarily added until the following issue gets resolved
+# https://github.com/pypa/pip/issues/6213
+pip-wheel-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# TODO: remove
 # Temporarily added until the following issue gets resolved
 # https://github.com/pypa/pip/issues/6213
 pip-wheel-metadata

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install:
 matrix:
   include:
     - stage: linting
-      python: 3.7
-      env: TOX_ENV="py37-linting"
+      python: 3.6
+      env: TOX_ENV="py36-linting"
 
     - stage: test
       python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install:
 matrix:
   include:
     - stage: linting
-      python: 3.6
-      env: TOX_ENV="py36-linting"
+      python: 3.7
+      env: TOX_ENV="py37-linting"
 
     - stage: test
       python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ python: 3.7
 
 dist: xenial
 
+stages:
+  - linting
+  - test
+
 before_install:
   - make rabbitmq-container
   - make redis-container
@@ -12,39 +16,43 @@ install:
 
 matrix:
   include:
+    - stage: linting
+      python: 3.7
+      env: TOX_ENV="py37-linting"
+
     - stage: test
       python: 3.5
-      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis2.10"
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis2.10-test"
     - python: 3.5
-      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.0"
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.0-test"
     - python: 3.5
-      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.1"
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.1-test"
     - python: 3.5
-      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.2"
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redis3.2-test"
     - python: 3.5
-      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redislatest"
+      env: TOX_ENV="py35-nameko{2.11,2.12,latest}-redislatest-test"
 
     - python: 3.6
-      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis2.10"
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis2.10-test"
     - python: 3.6
-      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.0"
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.0-test"
     - python: 3.6
-      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.1"
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.1-test"
     - python: 3.6
-      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.2"
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redis3.2-test"
     - python: 3.6
-      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redislatest"
+      env: TOX_ENV="py36-nameko{2.11,2.12,latest}-redislatest-test"
 
     - python: 3.7
-      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis2.10"
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis2.10-test"
     - python: 3.7
-      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.0"
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.0-test"
     - python: 3.7
-      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.1"
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.1-test"
     - python: 3.7
-      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.2"
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redis3.2-test"
     - python: 3.7
-      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redislatest"
+      env: TOX_ENV="py37-nameko{2.11,2.12,latest}-redislatest-test"
 
 script:
   - tox -e $TOX_ENV

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ flake8:
 	flake8 $(PACKAGE_NAME) test setup.py
 
 black:
-	black --check --verbose .
+	black --check --verbose --diff .
 
 linting: rst-lint flake8 black
 

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,15 @@ rst-lint:
 flake8:
 	flake8 $(PACKAGE_NAME) test setup.py
 
+black:
+	black --check --verbose .
+
 test:
 	pytest test $(ARGS) \
 		--rabbit-ctl-uri $(RABBIT_CTL_URI) \
 		--amqp-uri $(AMQP_URI)
 
-coverage: rst-lint flake8
+coverage: rst-lint flake8 black
 	coverage run \
 		--concurrency=eventlet \
 		--source $(PACKAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ flake8:
 black:
 	black --check --verbose --diff .
 
-linting: rst-lint flake8 black
+isort:
+	isort --recursive --check-only --diff
+
+linting: rst-lint flake8 black isort
 
 # Tests
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ RABBITMQ_VERSION?=3.6-management
 REDIS_VERSION?=4.0
 
 
+# Checks
+
 rst-lint:
 	rst-lint README.rst
 	rst-lint CHANGELOG.rst
@@ -20,12 +22,16 @@ flake8:
 black:
 	black --check --verbose .
 
+linting: rst-lint flake8 black
+
+# Tests
+
 test:
 	pytest test $(ARGS) \
 		--rabbit-ctl-uri $(RABBIT_CTL_URI) \
 		--amqp-uri $(AMQP_URI)
 
-coverage: rst-lint flake8 black
+coverage:
 	coverage run \
 		--concurrency=eventlet \
 		--source $(PACKAGE_NAME) \

--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,22 @@ variable:
     $ make coverage RABBIT_CTL_URI=http://guest:guest@localhost:15673 AMQP_URI=amqp://guest:guest@localhost:5673 ARGS='-x -vv --disable-warnings'
 
 
+Linting
+~~~~~~~
+
+To run linting checks using ``tox``:
+
+.. code-block:: shell
+
+    $ tox -e "py37-linting"
+
+A Makefile target can also be used directly:
+
+.. code-block:: shell
+
+    $ make linting
+
+
 Nameko support
 --------------
 

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,8 @@ variable:
 Linting
 ~~~~~~~
 
+It uses Python 3.6 syntax.
+
 To run linting checks using ``tox``:
 
 .. code-block:: shell

--- a/README.rst
+++ b/README.rst
@@ -147,19 +147,11 @@ variable:
 Linting
 ~~~~~~~
 
-It uses Python 3.6 syntax.
-
 To run linting checks using ``tox``:
 
 .. code-block:: shell
 
-    $ tox -e "py37-linting"
-
-A Makefile target can also be used directly:
-
-.. code-block:: shell
-
-    $ make linting
+    $ for env in $(tox -l - | grep linting); do tox -e $env; done
 
 
 Nameko support

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,9 @@ Nameko Redis Keyspace Notifications
 .. image:: https://travis-ci.org/sohonetlabs/nameko-rediskn.svg?branch=master
     :target: https://travis-ci.org/sohonetlabs/nameko-rediskn
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/psf/black
+
 
 Usage
 -----

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -1,11 +1,9 @@
 import logging
 from itertools import chain
 
-from redis import StrictRedis
-
 from nameko.exceptions import ConfigurationError
 from nameko.extensions import Entrypoint
-
+from redis import StrictRedis
 
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
 

--- a/nameko_rediskn/rediskn.py
+++ b/nameko_rediskn/rediskn.py
@@ -118,9 +118,7 @@ class RedisKNEntrypoint(Entrypoint):
                 # ...
     """
 
-    def __init__(
-        self, uri_config_key, events=None, keys=None, dbs=None, **kwargs
-    ):
+    def __init__(self, uri_config_key, events=None, keys=None, dbs=None, **kwargs):
         """Initialize the entrypoint.
 
         Args:
@@ -141,15 +139,11 @@ class RedisKNEntrypoint(Entrypoint):
 
     def setup(self):
         if not self.events and not self.keys:
-            error_message = (
-                'Provide either `events` or `keys` to get notifications'
-            )
+            error_message = 'Provide either `events` or `keys` to get notifications'
             log.error(error_message)
             raise ConfigurationError(error_message)
 
-        self._redis_uri = self.container.config['REDIS_URIS'][
-            self.uri_config_key
-        ]
+        self._redis_uri = self.container.config['REDIS_URIS'][self.uri_config_key]
         redis_config = self.container.config.get('REDIS', {})
         self._notification_events = redis_config.get('notification_events')
         super().setup()
@@ -190,9 +184,7 @@ class RedisKNEntrypoint(Entrypoint):
 
         if self._notification_events is not None:
             # This should ideally be set in redis.conf
-            client.config_set(
-                NOTIFICATIONS_SETTING_KEY, self._notification_events
-            )
+            client.config_set(NOTIFICATIONS_SETTING_KEY, self._notification_events)
 
         self.client = client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [tool.black]
-line-length = 79
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [tool.black]
 skip-string-normalization = true
 target-version = ['py36', 'py37', 'py38']
+
+[tool.isort]
+line_length = 88
+include_trailing_comma = true
+use_parentheses = true
+multi_line_output = 3
+force_grid_wrap = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,5 @@ include_trailing_comma = true
 use_parentheses = true
 multi_line_output = 3
 force_grid_wrap = 0
+# Tests are not included with the package
+known_first_party = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.black]
 skip-string-normalization = true
+target-version = ['py36', 'py37', 'py38']

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             'pytest~=5.0.0',
             'coverage~=4.5.3',
             'flake8',
+            'flake8-bugbear',
             'black;python_version>"3.5"',
             'isort',
             'restructuredtext-lint',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 from codecs import open
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -43,5 +43,5 @@ setup(
         "Topic :: Database :: Front-Ends",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
-    ]
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email='julio.trigo@sohonet.com',
     url='https://github.com/sohonetlabs/nameko-rediskn',
     packages=find_packages(exclude=['test', 'test.*']),
+    keywords='nameko redis keyspace notifications extension',
     install_requires=['nameko>=2.6', 'redis>=2.10.5'],
     extras_require={
         'dev': [
@@ -31,10 +32,12 @@ setup(
     zip_safe=True,
     license='MIT License',
     classifiers=[
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
             'pytest~=5.0.0',
             'coverage~=4.5.3',
             'flake8',
-            'black',
+            'black;python_version>"3.5"',
             'restructuredtext-lint',
             'Pygments',
         ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
             'black',
             'restructuredtext-lint',
             'Pygments',
-        ],
+        ]
     },
     zip_safe=True,
     license='MIT License',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from codecs import open
-from setuptools import find_packages, setup
 
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -26,6 +26,7 @@ setup(
             'coverage~=4.5.3',
             'flake8',
             'black;python_version>"3.5"',
+            'isort',
             'restructuredtext-lint',
             'Pygments',
         ]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             'pytest~=5.0.0',
             'coverage~=4.5.3',
             'flake8',
+            'black',
             'restructuredtext-lint',
             'Pygments',
         ],

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
 TIME_SLEEP = 0.1
 URI_CONFIG_KEY = 'TEST_KEY'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,11 +10,19 @@ from test import REDIS_OPTIONS, TIME_SLEEP, URI_CONFIG_KEY
 
 
 @pytest.fixture
-def config():
+def redis_config():
     return {
         'REDIS': {'notification_events': 'KEA'},
         'REDIS_URIS': {URI_CONFIG_KEY: "redis://localhost:6379/0"},
     }
+
+
+@pytest.fixture
+def config(rabbit_config, redis_config):
+    conf = {}
+    conf.update(rabbit_config or {})
+    conf.update(redis_config or {})
+    return conf
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,9 +29,7 @@ def redis(config):
 @pytest.fixture
 def redis_db_1(config):
     # url argument takes precedence over db in the url
-    redis_uri = '{}?db=1'.format(
-        config['REDIS_URIS'][URI_CONFIG_KEY]
-    )
+    redis_uri = '{}?db=1'.format(config['REDIS_URIS'][URI_CONFIG_KEY])
     client = StrictRedis.from_url(redis_uri, db=1, **REDIS_OPTIONS)
     client.flushall()
     yield client

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -9,13 +9,11 @@ from test import assert_items_equal, TIME_SLEEP, URI_CONFIG_KEY
 
 
 class TestPublicConstants:
-
     def test_value(self):
         assert REDIS_PMESSAGE_TYPE == 'pmessage'
 
 
 class TestConfig:
-
     def test_raises_if_uri_config_key_not_found(self, create_service, config):
         config['REDIS_URIS'] = {'WRONG_KEY': "redis://localhost:6379/0"}
 
@@ -58,7 +56,6 @@ class TestConfig:
 
 
 class TestSubscribeAPI:
-
     def test_raises_if_uri_config_key_not_supplied(self, create_service):
         with pytest.raises(TypeError):
             create_service()
@@ -84,7 +81,6 @@ class TestSubscribeAPI:
 
 
 class TestContainerStop:
-
     def test_kills_thread_if_exists(self, create_service):
         with patch(
             'nameko.containers.ServiceContainer.spawn_managed_thread'
@@ -119,7 +115,6 @@ class TestContainerStop:
 
 
 class TestContainerKill:
-
     def test_kills_thread_if_exists(self, create_service):
         with patch(
             'nameko.containers.ServiceContainer.spawn_managed_thread'
@@ -154,7 +149,6 @@ class TestContainerKill:
 
 
 class TestLogInformation:
-
     def test_log_start_listening_information(self, create_service, log_mock):
         create_service(
             uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*'
@@ -177,7 +171,6 @@ class TestLogInformation:
 
 
 class TestListenAll:
-
     @pytest.fixture
     def service(self, create_service):
         return create_service(
@@ -205,7 +198,7 @@ class TestListenAll:
                         'data': 2,
                     }
                 ),
-            ]
+            ],
         )
 
     @pytest.mark.parametrize(
@@ -259,7 +252,7 @@ class TestListenAll:
                         'data': key,
                     }
                 ),
-            ]
+            ],
         )
 
     @pytest.mark.usefixtures('service')
@@ -319,7 +312,7 @@ class TestListenAll:
                         'data': 'foo',
                     }
                 ),
-            ]
+            ],
         )
 
     @pytest.mark.parametrize('keys', [('one',), ('one', 'two')])
@@ -380,7 +373,7 @@ class TestListenAll:
                         'data': 'foo',
                     }
                 ),
-            ]
+            ],
         )
 
     @pytest.mark.parametrize(
@@ -472,7 +465,6 @@ class TestListenAll:
 
 
 class TestListenEvents:
-
     def test_subscribe_events(self, create_service, tracker):
         create_service(
             uri_config_key=URI_CONFIG_KEY, events='psubscribe', dbs='*'
@@ -513,7 +505,7 @@ class TestListenEvents:
                         'data': 'foo',
                     }
                 ),
-            ]
+            ],
         )
 
     @pytest.mark.parametrize('events', [['set', 'hset'], ('set', 'hset')])
@@ -579,7 +571,6 @@ class TestListenEvents:
 
 
 class TestListenKeys:
-
     def test_subscribe_events(self, create_service, tracker):
         create_service(uri_config_key=URI_CONFIG_KEY, keys='foo', dbs='*')
         assert tracker.call_args_list == [
@@ -618,7 +609,7 @@ class TestListenKeys:
                         'data': 'set',
                     }
                 ),
-            ]
+            ],
         )
 
     @pytest.mark.parametrize('keys', [['foo', 'bar'], ('foo', 'bar')])
@@ -684,7 +675,6 @@ class TestListenKeys:
 
 
 class TestListenDB:
-
     def test_subscribes_to_db_from_uri(self, create_service, tracker):
         create_service(uri_config_key=URI_CONFIG_KEY, keys='*', events='*')
         assert tracker.call_args_list == [
@@ -772,7 +762,7 @@ class TestListenDB:
                         'data': 'foo',
                     }
                 ),
-            ]
+            ],
         )
 
     def test_listen_multiple_dbs(

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -1,11 +1,11 @@
-from unittest.mock import call, patch, MagicMock
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from eventlet import sleep
 from nameko.exceptions import ConfigurationError
 
 from nameko_rediskn import REDIS_PMESSAGE_TYPE
-from test import assert_items_equal, TIME_SLEEP, URI_CONFIG_KEY
+from test import TIME_SLEEP, URI_CONFIG_KEY, assert_items_equal
 
 
 class TestPublicConstants:

--- a/test/test_rediskn.py
+++ b/test/test_rediskn.py
@@ -28,15 +28,11 @@ class TestConfig:
 
         assert exc.value.args[0] == 'TEST_KEY'
 
-    def test_uses_notification_events_config_if_provided(
-        self, create_service, config
-    ):
+    def test_uses_notification_events_config_if_provided(self, create_service, config):
         config['REDIS']['notification_events'] = 'test_value'
 
         with patch('nameko_rediskn.rediskn.StrictRedis') as strict_redis_mock:
-            create_service(
-                uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*'
-            )
+            create_service(uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*')
             redis_mock = strict_redis_mock.from_url.return_value
             assert redis_mock.config_set.call_args_list == [
                 call('notify-keyspace-events', 'test_value')
@@ -48,9 +44,7 @@ class TestConfig:
         config['REDIS'].pop('notification_events')
 
         with patch('nameko_rediskn.rediskn.StrictRedis') as strict_redis_mock:
-            create_service(
-                uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*'
-            )
+            create_service(uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*')
             redis_mock = strict_redis_mock.from_url.return_value
             assert redis_mock.config_set.call_args_list == []
 
@@ -150,9 +144,7 @@ class TestContainerKill:
 
 class TestLogInformation:
     def test_log_start_listening_information(self, create_service, log_mock):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*')
         assert log_mock.info.call_args_list == [
             call('Started listening to Redis keyspace notifications')
         ]
@@ -466,9 +458,7 @@ class TestListenAll:
 
 class TestListenEvents:
     def test_subscribe_events(self, create_service, tracker):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, events='psubscribe', dbs='*'
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, events='psubscribe', dbs='*')
         assert tracker.call_args_list == [
             call(
                 {
@@ -509,9 +499,7 @@ class TestListenEvents:
         )
 
     @pytest.mark.parametrize('events', [['set', 'hset'], ('set', 'hset')])
-    def test_listen_multiple_events(
-        self, create_service, tracker, redis, events
-    ):
+    def test_listen_multiple_events(self, create_service, tracker, redis, events):
         create_service(uri_config_key=URI_CONFIG_KEY, events=events, dbs='*')
 
         redis.set('foo', 'bar')
@@ -697,9 +685,7 @@ class TestListenDB:
         ]
 
     def test_subscribe_events(self, create_service, tracker):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=1
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=1)
         assert tracker.call_args_list == [
             call(
                 {
@@ -720,9 +706,7 @@ class TestListenDB:
         ]
 
     def test_listen_db(self, create_service, tracker, redis_db_1):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=1
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=1)
 
         redis_db_1.set('foo', 'bar')
         sleep(TIME_SLEEP)
@@ -765,12 +749,8 @@ class TestListenDB:
             ],
         )
 
-    def test_listen_multiple_dbs(
-        self, create_service, tracker, redis, redis_db_1
-    ):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=[0, 1]
-        )
+    def test_listen_multiple_dbs(self, create_service, tracker, redis, redis_db_1):
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=[0, 1])
 
         redis.set('foo', '1')
         sleep(TIME_SLEEP)
@@ -853,9 +833,7 @@ class TestListenDB:
         assert_items_equal(tracker.call_args_list, call_args_list)
 
     def test_ignores_other_dbs(self, create_service, tracker, redis_db_1):
-        create_service(
-            uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=0
-        )
+        create_service(uri_config_key=URI_CONFIG_KEY, keys='*', events='*', dbs=0)
         tracker.reset_mock()
 
         redis_db_1.set('foo', 'bar')

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,6 @@ deps =
 commands =
     linting: make linting
     test: make coverage ARGS='-vv'
+
+[flake8]
+max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36}-linting, {py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}-test
+envlist = {py37}-linting, {py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}-test
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,7 @@ commands =
 # https://gitlab.com/pycqa/flake8/issues/428
 # https://gitlab.com/pycqa/flake8/merge_requests/245
 [flake8]
-max-line-length = 88
+ignore = E501, W503
+max-line-length = 80
+max-complexity = 10
+select = C,E,F,W,B,B9

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,8 @@ commands =
     linting: make linting
     test: make coverage ARGS='-vv'
 
+# TODO: move to pyproject.toml when the following work lands:
+# https://gitlab.com/pycqa/flake8/issues/428
+# https://gitlab.com/pycqa/flake8/merge_requests/245
 [flake8]
 max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py37}-linting, {py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}-test
+envlist = {py36}-linting, {py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}-test
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}
+envlist = {py37}-linting, {py35,py36,py37}-nameko{2.11,2.12,latest}-redis{2.10,3.0,3.1,3.2,latest}-test
 skipsdist = True
 
 [testenv]
@@ -14,4 +14,5 @@ deps =
     redis3.1: redis>=3.1,<3.2
     redis3.2: redis>=3.2,<3.3
 commands =
-    make coverage ARGS='-vv'
+    linting: make linting
+    test: make coverage ARGS='-vv'


### PR DESCRIPTION
* Add Black code formatting:
  * Omit checks for string quotes
  * Use default line length: `88`
  * Python versions supported by Black's output: `py36`, `py37` and `py38`
  * Amend code formatting
* Amend `flake8` config:
  * Add `flake8-bugbear` plugin
  * Amend configuration
* Add `isort` code formatting:
  * Fix `test` order when using `tox`
  * Amend code formatting
* Add `pyproject.toml`:
  * As described in [PEP 518](https://www.python.org/dev/peps/pep-0518/)
  * Contains Black and isort settings
  * In preparation for additional settings to be added here soon
* Split linting and test:
  * Avoid running linting for each one of the test jobs
  * Black does not support Python 3.5
  * Do not run linting as part of `coverage`
* Add extra options to package setup:
  * Development Status: Beta
  * Python 3 only
  * `keywords`
* Make `pytest` config fixtures more explicit so that they can be easily reused
* Temporarily add `pip-wheel-metadata` to `.gitignore` until the following issue gets resolved: https://github.com/pypa/pip/issues/6213