### PR TITLE
Reconnect on error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ nameko-rediskn versions, where semantic versioning is used:
 
 Backwards-compatible changes increment the minor version number only.
 
+0.1.1
+-----
+
+Released: TBD
+
+* Reconnect to redis on errors (`#6 <https://github.com/sohonetlabs/nameko-rediskn/pull/6>`_)
 
 0.1.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Backwards-compatible changes increment the minor version number only.
 Released: TBD
 
 * Reconnect to redis on errors (`#6 <https://github.com/sohonetlabs/nameko-rediskn/pull/6>`_)
+* New config key ``pubsub_backoff_factor`` (`#6 <https://github.com/sohonetlabs/nameko-rediskn/pull/6>`_)
 
 0.1.0
 -----

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,3 +2,4 @@ Contributions have been made by:
 
 Alex Peitsinis (@alexpeits)
 Julio Trigo (@juliotrigo)
+Heinrich Kruger (@heindsight)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test:
 coverage:
 	coverage run \
 		--concurrency=eventlet \
-		--source src/$(PACKAGE_NAME) \
+		--source $(PACKAGE_NAME) \
 		--branch \
 		-m pytest $(TESTS_PACKAGE_NAME) $(ARGS) \
 		--rabbit-ctl-uri $(RABBIT_CTL_URI) \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test:
 coverage:
 	coverage run \
 		--concurrency=eventlet \
-		--source $(PACKAGE_NAME) \
+		--source src/$(PACKAGE_NAME) \
 		--branch \
 		-m pytest $(TESTS_PACKAGE_NAME) $(ARGS) \
 		--rabbit-ctl-uri $(RABBIT_CTL_URI) \

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ Nameko_ configuration file:
 
     REDIS:
         notification_events: "KEA"
+        pubsub_backoff_factor: 3
 
     REDIS_URIS:
         MY_REDIS: "redis://localhost:6380/0"
@@ -93,6 +94,12 @@ contain ``None``. Otherwise, it must have a valid value for the
 ``'notify-keyspace-events'`` Redis client configuration attribute. This
 should be ideally set on the server side, as setting it in one of the
 Redis clients will affect the rest of them.
+
+``REDIS[pubsub_backoff_factor]`` sets the exponential backoff factor for
+reconnecting to Redis on errors. If an error occurs while listening for Redis
+events, we sleep for ``backoff_factor * 2 ** (n - 1)`` where ``n`` is the
+number of consecutive errors that have occurred. If omitted, this defaults
+to ``2``.
 
 ``REDIS_URIS`` follows the config format used by the `Nameko Redis`_
 dependency provider, where ``MY_REDIS`` is just the attribute name

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=['nameko>=2.6', 'redis>=2.10.5'],
     extras_require={
         'dev': [
-            'pytest~=5.0.0',
+            'pytest<5.0.0',
             'coverage~=4.5.3',
             'flake8',
             'flake8-bugbear',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(here, 'README.rst'), 'r', 'utf-8') as handle:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from codecs import open
 
 from setuptools import find_packages, setup
 
-
 here = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(here, 'README.rst'), 'r', 'utf-8') as handle:

--- a/src/nameko_rediskn/rediskn.py
+++ b/src/nameko_rediskn/rediskn.py
@@ -6,7 +6,6 @@ from nameko.exceptions import ConfigurationError
 from nameko.extensions import Entrypoint
 from redis import StrictRedis
 
-
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
 
 NOTIFICATIONS_SETTING_KEY = 'notify-keyspace-events'

--- a/src/nameko_rediskn/rediskn.py
+++ b/src/nameko_rediskn/rediskn.py
@@ -2,10 +2,9 @@ import logging
 from itertools import chain
 
 from eventlet import sleep
-from redis import StrictRedis
-
 from nameko.exceptions import ConfigurationError
 from nameko.extensions import Entrypoint
+from redis import StrictRedis
 
 
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
@@ -184,7 +183,7 @@ class RedisKNEntrypoint(Entrypoint):
                 try:
                     pubsub = self._subscribe()
 
-                    for message in pubsub.listen():  #pragma: no branch
+                    for message in pubsub.listen():  # pragma: no branch
                         error_count = 0
                         self.container.spawn_worker(self, [message], {})
                 except Exception:

--- a/src/nameko_rediskn/rediskn.py
+++ b/src/nameko_rediskn/rediskn.py
@@ -159,14 +159,17 @@ class RedisKNEntrypoint(Entrypoint):
     def start(self):
         self._thread = self.container.spawn_managed_thread(self._run)
         super().start()
+        log.debug("%s started", self)
 
     def stop(self):
         self._kill_thread()
         super().stop()
+        log.debug("%s stopped", self)
 
     def kill(self):
         self._kill_thread()
         super().kill()
+        log.debug("%s killed", self)
 
     def _run(self):
         """Run the main loop which listens for subscription events."""
@@ -211,6 +214,7 @@ class RedisKNEntrypoint(Entrypoint):
         self.client = client
 
     def _subscribe(self):
+        log.debug('%s setting up redis subscriptions', self)
         pubsub = self.client.pubsub()
 
         keyevent_patterns = (

--- a/src/nameko_rediskn/rediskn.py
+++ b/src/nameko_rediskn/rediskn.py
@@ -32,7 +32,6 @@ KEYSPACE_TEMPLATE = '__keyspace@{db}__:{key}'
 REDIS_PMESSAGE_TYPE = 'pmessage'
 """Pattern-matching subscription message type."""
 
-
 DEFAULT_BACKOFF_FACTOR = 2
 """
 Default backoff factor for exponential backoff on errors while listening for

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
 TIMEOUT = 0.5
 TIME_SLEEP = 0.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
+TIMEOUT = 0.5
 TIME_SLEEP = 0.1
 URI_CONFIG_KEY = 'TEST_KEY'
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+
 REDIS_OPTIONS = {'encoding': 'utf-8', 'decode_responses': True}
 TIMEOUT = 0.5
 TIME_SLEEP = 0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 from unittest.mock import Mock, patch
 
-import pytest
 import eventlet
+import pytest
 from eventlet import sleep
 from redis import StrictRedis
 
@@ -77,11 +77,11 @@ def log_mock():
         yield log_mock
 
 
-
 @pytest.fixture
 def mock_strict_redis():
     with patch('nameko_rediskn.rediskn.StrictRedis') as m:
         yield m
+
 
 @pytest.fixture
 def mock_redis_client(mock_strict_redis):

--- a/tests/test_rediskn.py
+++ b/tests/test_rediskn.py
@@ -1,11 +1,13 @@
+import logging
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+import eventlet
 from eventlet import sleep
 from nameko.exceptions import ConfigurationError
 
 from nameko_rediskn import REDIS_PMESSAGE_TYPE
-from tests import TIME_SLEEP, URI_CONFIG_KEY, assert_items_equal
+from tests import TIMEOUT, TIME_SLEEP, URI_CONFIG_KEY, assert_items_equal
 
 
 class TestPublicConstants:
@@ -28,25 +30,27 @@ class TestConfig:
 
         assert exc.value.args[0] == 'TEST_KEY'
 
-    def test_uses_notification_events_config_if_provided(self, create_service, config):
+    def test_uses_notification_events_config_if_provided(
+        self, create_service, config, mock_redis_client, mock_pubsub
+    ):
+        event = eventlet.Event()
+        mock_pubsub.listen.side_effect = event.wait
         config['REDIS']['notification_events'] = 'test_value'
 
-        with patch('nameko_rediskn.rediskn.StrictRedis') as strict_redis_mock:
-            create_service(uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*')
-            redis_mock = strict_redis_mock.from_url.return_value
-            assert redis_mock.config_set.call_args_list == [
-                call('notify-keyspace-events', 'test_value')
-            ]
+        create_service(uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*')
+        assert mock_redis_client.config_set.call_args_list == [
+            call('notify-keyspace-events', 'test_value')
+        ]
 
     def test_does_not_use_notification_events_config_if_not_provided(
-        self, create_service, config
+        self, create_service, config, mock_redis_client, mock_pubsub
     ):
+        event = eventlet.Event()
+        mock_pubsub.listen.side_effect = event.wait
         config['REDIS'].pop('notification_events')
 
-        with patch('nameko_rediskn.rediskn.StrictRedis') as strict_redis_mock:
-            create_service(uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*')
-            redis_mock = strict_redis_mock.from_url.return_value
-            assert redis_mock.config_set.call_args_list == []
+        create_service(uri_config_key=URI_CONFIG_KEY, events='*', keys='*', dbs='*')
+        assert mock_redis_client.config_set.call_args_list == []
 
 
 class TestSubscribeAPI:
@@ -74,72 +78,42 @@ class TestSubscribeAPI:
         ]
 
 
-class TestContainerStop:
-    def test_kills_thread_if_exists(self, create_service):
+class TestStopKill:
+    @pytest.fixture
+    def mock_thread(self):
         with patch(
             'nameko.containers.ServiceContainer.spawn_managed_thread'
         ) as spawn_managed_thread:
-            thread_mock = MagicMock()
-            thread_mock.kill.return_value = MagicMock()
-            spawn_managed_thread.return_value = thread_mock
-            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
-            service.container.stop()
+            yield spawn_managed_thread.return_value
 
-        assert thread_mock.kill.call_args_list == [call()]
+    def test_container_stop(self, create_service, mock_thread):
+        service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
+        service.container.stop()
 
-        entrypoint = next(iter(service.container.entrypoints))
-        assert entrypoint._thread is None
-        assert entrypoint.client is None
+        assert mock_thread.kill.call_args_list == [call()]
 
-    def test_does_not_kill_thread_if_not_exists(self, create_service):
-        with patch(
-            'nameko.containers.ServiceContainer.spawn_managed_thread'
-        ) as spawn_managed_thread:
-            thread_mock = MagicMock()
-            thread_mock.kill.return_value = MagicMock()
-            spawn_managed_thread.return_value = None
-            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
-            service.container.stop()
+    def test_container_kill(self, create_service, mock_thread):
+        service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
+        service.container.kill()
 
-        assert thread_mock.kill.call_args_list == []
+        # nameko will call `RedisKNEntrypoint.kill` twice for each `rediskn`
+        # entrypoint (because it shows up both as an entrypoint and an
+        # extension)
+        assert mock_thread.kill.call_args_list == [call(), call()]
 
-        entrypoint = next(iter(service.container.entrypoints))
-        assert entrypoint._thread is None
-        assert entrypoint.client is None
+    @pytest.mark.parametrize('method', ['stop', 'kill'])
+    def test_stop_entrypoint(self, mock_pubsub, entrypoint, method):
+        event = eventlet.Event()
+        mock_pubsub.listen.side_effect = event.wait
+        stop_method = getattr(entrypoint, method)
+        entrypoint.setup()
 
+        with eventlet.Timeout(TIMEOUT):
+            entrypoint.start()
+            sleep(TIME_SLEEP)
+            stop_method()
 
-class TestContainerKill:
-    def test_kills_thread_if_exists(self, create_service):
-        with patch(
-            'nameko.containers.ServiceContainer.spawn_managed_thread'
-        ) as spawn_managed_thread:
-            thread_mock = MagicMock()
-            thread_mock.kill.return_value = MagicMock()
-            spawn_managed_thread.return_value = thread_mock
-            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
-            service.container.kill()
-
-        assert thread_mock.kill.call_args_list == [call()]
-
-        entrypoint = next(iter(service.container.entrypoints))
-        assert entrypoint._thread is None
-        assert entrypoint.client is None
-
-    def test_does_not_kill_thread_if_not_exists(self, create_service):
-        with patch(
-            'nameko.containers.ServiceContainer.spawn_managed_thread'
-        ) as spawn_managed_thread:
-            thread_mock = MagicMock()
-            thread_mock.kill.return_value = MagicMock()
-            spawn_managed_thread.return_value = None
-            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
-            service.container.kill()
-
-        assert thread_mock.kill.call_args_list == []
-
-        entrypoint = next(iter(service.container.entrypoints))
-        assert entrypoint._thread is None
-        assert entrypoint.client is None
+        assert entrypoint._thread.dead is True
 
 
 class TestLogInformation:
@@ -159,6 +133,220 @@ class TestLogInformation:
 
         assert log_mock.info.call_args_list == [
             call('Stopped listening to Redis keyspace notifications')
+        ]
+
+
+def redis_listen(*side_effects):
+    """Mock the redis pubsub.listen generator
+
+    Yields the elements of `side_effects`, one at a time. If an element is an
+    exception, it is raised instead of yielded. If the element is a callable,
+    it is called and the return value is yielded.
+    """
+    for effect in side_effects:
+        if (
+            isinstance(effect, Exception) or
+            isinstance(effect, type) and issubclass(effect, Exception)
+        ):
+            raise effect
+        elif callable(effect):
+            yield effect()
+        else:
+            yield effect
+
+
+class TestErrorHandling:
+    @pytest.fixture
+    def mock_sleep(self):
+        with patch('nameko_rediskn.rediskn.sleep') as m:
+            yield m
+
+    @pytest.mark.usefixtures('mock_sleep')
+    def test_error_subscribing(self, mock_redis_client, entrypoint):
+        mock_pubsub_1 = MagicMock()
+        mock_pubsub_2 = MagicMock()
+        mock_redis_client.pubsub.side_effect = [
+            mock_pubsub_1,
+            mock_pubsub_2
+        ]
+        mock_pubsub_1.psubscribe.side_effect = [None, ConnectionError('Boom!')]
+        event = eventlet.Event()
+        mock_pubsub_2.psubscribe.return_value = None
+        mock_pubsub_2.listen.side_effect = event.wait
+        entrypoint.setup()
+
+        with eventlet.Timeout(TIMEOUT):
+            entrypoint.start()
+            sleep(TIME_SLEEP)
+            entrypoint.stop()
+
+        assert mock_redis_client.pubsub.call_args_list == [call(), call()]
+        assert mock_pubsub_1.psubscribe.call_args_list == [
+            call('__keyevent@0__:*'), call('__keyspace@0__:*')
+        ]
+        assert not mock_pubsub_1.listen.called
+        assert mock_pubsub_2.psubscribe.call_args_list == [
+            call('__keyevent@0__:*'), call('__keyspace@0__:*')
+        ]
+        assert mock_pubsub_2.listen.call_args_list == [call()]
+
+    @pytest.mark.parametrize(
+        'exception',
+        [ConnectionError('BOOM'), TimeoutError('BOOM'), Exception('BOOM')]
+    )
+    @pytest.mark.usefixtures('mock_sleep')
+    def test_reconnect_on_error(
+        self, create_service, mock_redis_client, tracker, caplog,
+        exception
+    ):
+        event = eventlet.Event()
+        mock_pubsub_1 = MagicMock()
+        mock_pubsub_2 = MagicMock()
+        mock_redis_client.pubsub.side_effect = [
+            mock_pubsub_1,
+            mock_pubsub_2
+        ]
+        mock_pubsub_1.listen.side_effect = exception
+        mock_pubsub_2.listen.return_value = redis_listen(
+            {
+                'type': 'pmessage',
+                'pattern': '__keyspace@*__:*',
+                'channel': '__keyspace@0__:foo',
+                'data': 'expire',
+            },
+            event.wait
+        )
+
+        with eventlet.Timeout(TIMEOUT):
+            service = create_service(uri_config_key=URI_CONFIG_KEY, events='*')
+            service.container.stop()
+
+        assert mock_redis_client.pubsub.call_args_list == [call(), call()]
+        assert (
+            'nameko_rediskn.rediskn', logging.ERROR,
+            'Error while listening for redis keyspace notifications'
+        ) in caplog.record_tuples
+        assert mock_pubsub_1.listen.call_args_list == [call()]
+        assert mock_pubsub_2.listen.call_args_list == [call()]
+        assert tracker.call_args_list == [
+            call({
+                'type': 'pmessage',
+                'pattern': '__keyspace@*__:*',
+                'channel': '__keyspace@0__:foo',
+                'data': 'expire',
+            })
+        ]
+
+    @pytest.mark.parametrize(
+        'backoff_factor, sleep_durations',
+        [
+            (0, [0, 0, 0, 0, 0]),
+            (0.5, [0.5, 1.0, 2.0, 4.0, 0.5]),
+            (1, [1, 2, 4, 8, 1]),
+            (3, [3, 6, 12, 24, 3]),
+        ]
+    )
+    def test_exponential_backoff_listen_error(
+        self, entrypoint, config, mock_pubsub, mock_sleep, backoff_factor,
+        sleep_durations
+    ):
+        config['REDIS'] = {'pubsub_backoff_factor': backoff_factor}
+        entrypoint.setup()
+        event = eventlet.Event()
+        mock_pubsub.listen.side_effect = [
+            ConnectionError('Error1'),
+            Exception('Error2'),
+            ConnectionError('Error3'),
+            TimeoutError('Error4'),
+            redis_listen(
+                {
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@*__:*',
+                    'channel': '__keyspace@0__:foo',
+                    'data': 'expire',
+                },
+                ConnectionError('Error5')
+            ),
+            redis_listen(event.wait)
+        ]
+
+        with eventlet.Timeout(TIMEOUT):
+            entrypoint.start()
+            sleep(TIME_SLEEP)
+            entrypoint.stop()
+
+        assert mock_sleep.call_args_list == [
+            call(duration) for duration in sleep_durations
+        ]
+
+    def test_default_backoff_factor_listen_error(
+        self, entrypoint, config, mock_pubsub, mock_sleep
+    ):
+        config['REDIS'].pop('pubsub_backoff_factor', None)
+        entrypoint.setup()
+        event = eventlet.Event()
+        mock_pubsub.listen.side_effect = [
+            ConnectionError('Error1'),
+            Exception('Error2'),
+            ConnectionError('Error3'),
+            TimeoutError('Error4'),
+            redis_listen(
+                {
+                    'type': 'pmessage',
+                    'pattern': '__keyspace@*__:*',
+                    'channel': '__keyspace@0__:foo',
+                    'data': 'expire',
+                },
+                ConnectionError('Error5')
+            ),
+            redis_listen(event.wait)
+        ]
+
+        with eventlet.Timeout(TIMEOUT):
+            entrypoint.start()
+            sleep(TIME_SLEEP)
+            entrypoint.stop()
+
+        assert mock_sleep.call_args_list == [
+            call(2),
+            call(4),
+            call(8),
+            call(16),
+            call(2),
+        ]
+
+    @pytest.mark.parametrize(
+        'backoff_factor, sleep_durations',
+        [
+            (0, [0, 0, 0, 0]),
+            (0.5, [0.5, 1.0, 2.0, 4.0]),
+            (1, [1, 2, 4, 8]),
+            (3, [3, 6, 12, 24]),
+        ]
+    )
+    def test_exponential_backoff_subscribe_error(
+        self, entrypoint, config, mock_pubsub, mock_sleep, backoff_factor,
+        sleep_durations
+    ):
+        config['REDIS'] = {'pubsub_backoff_factor': backoff_factor}
+        entrypoint.setup()
+        event = eventlet.Event()
+        mock_pubsub.psubscribe.side_effect = [
+            ConnectionError('Error1'),
+            Exception('Error2'),
+            ConnectionError('Error3'),
+            TimeoutError('Error4'),
+            None, None  # Subscribes successfully
+        ]
+        mock_pubsub.listen.side_effect = event.wait
+
+        with eventlet.Timeout(TIMEOUT):
+            entrypoint.start()
+            sleep(TIME_SLEEP)
+            entrypoint.stop()
+
+        assert mock_sleep.call_args_list == [
+            call(duration) for duration in sleep_durations
         ]
 
 


### PR DESCRIPTION
Handle any errors that occur while listening for redis events by
attempting to reconnect to redis. This fixes a bug where a redis
failover would kill an entire service due to an unhandled exception
(redis `ConnectionError`) in the managed thread.

To allow redis (or the network) to recover from the condition that
caused the error, we use an exponential backoff when attempting to
reconnect. The backoff factor can be configured via the
`pubsub_backoff_factor` config.

- [x] Implement error handling
- [x] Update README

## Note
I have pinned `pytest < 5.0` in `setup.py` because of this pytest bug: https://github.com/pytest-dev/pytest/issues/5725